### PR TITLE
Bump version to 0.3.0 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "recsa"
-version = "0.2.0"
+version = "0.3.0"
 description = "Reaction Explorer for Coordination Self-Assembly"
 authors = ["neji-craftsman <142223934+neji-craftsman@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
This pull request includes a version update for the `recsa` project in the `pyproject.toml` file.

* Updated the project version from `0.2.0` to `0.3.0`.