### PR TITLE
Refactor bondset functions to use generic types for improved flexibility

### DIFF
--- a/recsa/bondset_enumeration/core.py
+++ b/recsa/bondset_enumeration/core.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Hashable, Iterable, Mapping
+from typing import TypeVar
 
 from .lib import enum_multi_bond_subsets, enum_single_bond_subsets
 
 __all__ = ['enum_bond_subsets']
 
+_T = TypeVar('_T', bound=Hashable)
+
 
 def enum_bond_subsets(
-        bonds: Iterable[int],
-        bond_to_adj_bonds: Mapping[int, Iterable[int]], 
-        sym_ops: Mapping[str, Mapping[int, int]] | None = None
-        ) -> set[frozenset[int]]:
+        bonds: Iterable[_T],
+        bond_to_adj_bonds: Mapping[_T, Iterable[_T]], 
+        sym_ops: Mapping[str, Mapping[_T, _T]] | None = None
+        ) -> set[frozenset[_T]]:
     """Enumerate connected subsets of bonds excluding symmetry-equivalent ones.
 
     When an assembly is represented as a set of bonds, subsets of 
@@ -44,15 +47,15 @@ def enum_bond_subsets(
 
     Parameters
     ----------
-    bonds : Iterable[int]
+    bonds : Iterable[_T]
         An iterable of bond IDs.
         The resulting bondsets are dependent on the order of the bonds.
-    bond_to_adj_bonds : Mapping[int, Iterable[int]]
+    bond_to_adj_bonds : Mapping[_T, Iterable[_T]]
         A dictionary mapping a bond to its adjacent bonds.
         Each key is the ID of a bond, and its value is an iterable
         of IDs of adjacent bonds.
         This dictionary is used for connectivity check.
-    sym_ops : Mapping[str, Mapping[int, int]] | None, optional
+    sym_ops : Mapping[str, Mapping[_T, _T]] | None, optional
         A dictionary of symmetry operations.
         Each key is the name of a symmetry operation, and its value is
         a mapping of bond IDs to their images under the symmetry operation.
@@ -64,7 +67,7 @@ def enum_bond_subsets(
 
     Returns
     -------
-    set[frozenset[int]]
+    set[frozenset[_T]]
         A set of connected subsets of bonds excluding symmetry-equivalent
         ones. Each subset is represented as a frozenset of bond IDs.
 
@@ -114,7 +117,7 @@ def enum_bond_subsets(
     >>> recsa.enum_bond_subsets(BONDS, BOND_TO_ADJ_BONDS, SYM_OPS)
     {frozenset({1}), frozenset({1, 2}), frozenset({1, 2, 3})}
     """
-    found: set[frozenset[int]] = set()
+    found: set[frozenset[_T]] = set()
 
     single_bond_subsets = enum_single_bond_subsets(bonds, sym_ops)
     found.update(single_bond_subsets)

--- a/recsa/bondset_enumeration/lib/is_new_check.py
+++ b/recsa/bondset_enumeration/lib/is_new_check.py
@@ -1,14 +1,17 @@
-from collections.abc import Mapping
+from collections.abc import Hashable, Mapping
+from typing import TypeVar
 
 from .symmetry_application import apply_symmetry_operation
 
 __all__ = ['is_new_under_symmetry']
 
+_T = TypeVar('_T', bound=Hashable)
+
 
 def is_new_under_symmetry(
-        found_assems: set[frozenset[int]],
-        new_assem: set[int],
-        sym_ops: Mapping[str, Mapping[int, int]] | None = None
+        found_assems: set[frozenset[_T]],
+        new_assem: set[_T],
+        sym_ops: Mapping[str, Mapping[_T, _T]] | None = None
         ) -> bool:
     """Check if a new assembly is not symmetry-equivalent to the found ones.
 

--- a/recsa/bondset_enumeration/lib/multi_bond.py
+++ b/recsa/bondset_enumeration/lib/multi_bond.py
@@ -1,4 +1,5 @@
-from collections.abc import Iterable, Mapping
+from collections.abc import Hashable, Iterable, Mapping
+from typing import TypeVar
 
 from recsa import sort_bondsets
 
@@ -6,12 +7,13 @@ from .is_new_check import is_new_under_symmetry
 
 __all__ = ['enum_multi_bond_subsets']
 
+_T = TypeVar('_T', bound=Hashable)
 
 def enum_multi_bond_subsets(
-        prev_assems: set[frozenset[int]],
-        bond_to_adj_bonds: Mapping[int, Iterable[int]],
-        sym_ops: Mapping[str, Mapping[int, int]] | None = None
-        ) -> set[frozenset[int]]:
+        prev_assems: set[frozenset[_T]],
+        bond_to_adj_bonds: Mapping[_T, Iterable[_T]],
+        sym_ops: Mapping[str, Mapping[_T, _T]] | None = None
+        ) -> set[frozenset[_T]]:
     """Enumerate multi-bond subsets of bonds
     excluding disconnected ones and symmetry-equivalent ones.
     """
@@ -19,13 +21,13 @@ def enum_multi_bond_subsets(
         bond: set(adj_bonds) 
         for bond, adj_bonds in bond_to_adj_bonds.items()}
     
-    found: set[frozenset[int]] = set()
+    found: set[frozenset[_T]] = set()
 
-    # NOTE: The order of the iteration should be fixed to make the 
+    # NOTE: The order of the iteration should be fixed to make the
     # result deterministic.
     for prev in sort_bondsets(prev_assems):
         # List adjacent bonds to the bonds in the previous assembly.
-        adj_bonds: set[int] = set()
+        adj_bonds: set[_T] = set()
         for bond in prev:
             adj_bonds.update(bond_to_adj_bonds[bond])
         # Bonds in the previous assembly should be excluded.

--- a/recsa/bondset_enumeration/lib/single_bond.py
+++ b/recsa/bondset_enumeration/lib/single_bond.py
@@ -1,18 +1,21 @@
-from collections.abc import Iterable, Mapping
+from collections.abc import Hashable, Iterable, Mapping
+from typing import TypeVar
 
 from .is_new_check import is_new_under_symmetry
 
 __all__ = ['enum_single_bond_subsets']
 
+_T = TypeVar('_T', bound=Hashable)
+
 
 def enum_single_bond_subsets(
-        bonds: Iterable[int],
-        sym_ops: Mapping[str, Mapping[int, int]] | None = None
-        ) -> set[frozenset[int]]:
+        bonds: Iterable[_T],
+        sym_ops: Mapping[str, Mapping[_T, _T]] | None = None
+        ) -> set[frozenset[_T]]:
     """Enumerate single-bond subsets of bonds 
     excluding disconnected ones and symmetry-equivalent ones.
     """
-    found: set[frozenset[int]] = set()
+    found: set[frozenset[_T]] = set()
 
     # NOTE: The order of the iteration should be fixed to make the
     # result deterministic.

--- a/recsa/bondset_enumeration/lib/symmetry_application.py
+++ b/recsa/bondset_enumeration/lib/symmetry_application.py
@@ -1,11 +1,14 @@
-from collections.abc import Iterable, Mapping
+from collections.abc import Hashable, Iterable, Mapping
+from typing import TypeVar
 
 __all__ = ['apply_symmetry_operation']
 
+_T = TypeVar('_T', bound=Hashable)
+
 
 def apply_symmetry_operation(
-        bondset: Iterable[int],
-        sym_op: Mapping[int, int]
-        ) -> set[int]:
+        bondset: Iterable[_T],
+        sym_op: Mapping[_T, _T]
+        ) -> set[_T]:
     """Apply a symmetry operation to an assembly."""
     return set(sym_op[bond] for bond in bondset)

--- a/recsa/bondset_enumeration/tests/test_core.py
+++ b/recsa/bondset_enumeration/tests/test_core.py
@@ -134,5 +134,34 @@ def test_enum_bond_subsets_M4L4_square():
         BONDS, BOND_TO_ADJ_BONDS, SYMMETRY_OPS) == EXPECTED
 
 
+def test_string():
+    # M2L3 linear: L-M-L-M-L
+    # bonds: 1, 2, 3, 4 from left to right
+
+    # WITHOUT symmetry operations
+    BONDS = ['1', '2', '3', '4']
+    BOND_TO_ADJ_BONDS = {
+        '1': {'2'},
+        '2': {'1', '3'},
+        '3': {'2', '4'},
+        '4': {'3'},
+    }
+    
+    subsets = enum_bond_subsets(BONDS, BOND_TO_ADJ_BONDS)
+
+    assert subsets == {
+        frozenset({'1'}),
+        frozenset({'2'}),
+        frozenset({'3'}),
+        frozenset({'4'}),
+        frozenset({'1', '2'}),
+        frozenset({'2', '3'}),
+        frozenset({'3', '4'}),
+        frozenset({'1', '2', '3'}),
+        frozenset({'2', '3', '4'}),
+        frozenset({'1', '2', '3', '4'}),
+    }
+
+
 if __name__ == '__main__':
     pytest.main(['-vv', __file__])


### PR DESCRIPTION
This pull request includes updates to the `recsa/bondset_enumeration` module to generalize bond identifiers from integers to any hashable type. The changes primarily involve modifying type hints and adding a new type variable `_T` to ensure type safety.

Generalization of bond identifiers:

* [`recsa/bondset_enumeration/core.py`](diffhunk://#diff-bd438aa93e6aa5b4d91979219a54bf640ba73ac5754190772c3c47fb6527cda1L3-R17): Introduced a type variable `_T` and modified the `enum_bond_subsets` function to use `_T` instead of `int` for bond identifiers. [[1]](diffhunk://#diff-bd438aa93e6aa5b4d91979219a54bf640ba73ac5754190772c3c47fb6527cda1L3-R17) [[2]](diffhunk://#diff-bd438aa93e6aa5b4d91979219a54bf640ba73ac5754190772c3c47fb6527cda1L47-R58) [[3]](diffhunk://#diff-bd438aa93e6aa5b4d91979219a54bf640ba73ac5754190772c3c47fb6527cda1L67-R70) [[4]](diffhunk://#diff-bd438aa93e6aa5b4d91979219a54bf640ba73ac5754190772c3c47fb6527cda1L117-R120)
* [`recsa/bondset_enumeration/lib/is_new_check.py`](diffhunk://#diff-44c367c569860af708820ae941a828655ae31ed27f10d4a607d1e1c16e4d3549L1-R14): Updated the `is_new_under_symmetry` function to use the type variable `_T` for bond identifiers.
* [`recsa/bondset_enumeration/lib/multi_bond.py`](diffhunk://#diff-e190f874c1eada4e0c6786d12df616a1318a2e54f0580bed40f39050090b822dL1-R30): Modified the `enum_multi_bond_subsets` function to use `_T` for bond identifiers.
* [`recsa/bondset_enumeration/lib/single_bond.py`](diffhunk://#diff-a5d34eaa3d68d81d1dbce4e85222ecd10d86d68b6f480c260dc61c17f71fb61bL1-R18): Updated the `enum_single_bond_subsets` function to use `_T` for bond identifiers.
* [`recsa/bondset_enumeration/lib/symmetry_application.py`](diffhunk://#diff-7c749a6e0b3d9b66ced852fb896016fd6044b6dcfccb7d3cd0ec5d431a839efeL1-R12): Changed the `apply_symmetry_operation` function to use `_T` for bond identifiers.

Additionally, a new test case was added to verify the functionality with string bond identifiers.

* [`recsa/bondset_enumeration/tests/test_core.py`](diffhunk://#diff-54552e9b9ffc797019e2b1dd55980b3d4bf2d9155b48ca19d46825c4184e9889R137-R165): Added `test_string` to test `enum_bond_subsets` with string bond identifiers.