### PR TITLE
Fix output directory creation in write_output function

### DIFF
--- a/recsa/pipelines/lib/saving.py
+++ b/recsa/pipelines/lib/saving.py
@@ -16,7 +16,9 @@ def write_output(
         raise FileExistsError(f'Output file "{output_path}" already exists.')
     if verbose:
         print(f'Saving the results to "{output_path}"...')
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    dir_ = os.path.dirname(output_path)
+    if dir_:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
     with open(output_path, 'w') as f:
         yaml.safe_dump(data, f, default_flow_style=default_flow_style)
     if verbose:

--- a/recsa/pipelines/lib/tests/test_saving.py
+++ b/recsa/pipelines/lib/tests/test_saving.py
@@ -83,5 +83,17 @@ def test_verbose_false(tmp_path, capsys):
     assert f'Saving the results to "{output_path}"...' not in captured.out
 
 
+def test_write_output_with_filename_only(tmp_path):
+    output_path = tmp_path / "output.yaml"
+    data = {"key": "value"}
+    
+    write_output(str(output_path), data)
+    
+    assert os.path.exists(output_path)
+    with open(output_path, 'r') as f:
+        saved_data = yaml.safe_load(f)
+    assert saved_data == data
+
+
 if __name__ == '__main__':
     pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request includes changes to the `recsa/pipelines/lib/saving.py` and `recsa/pipelines/lib/tests/test_saving.py` files to enhance file saving functionality and add corresponding tests.

Enhancements to file saving functionality:

* [`recsa/pipelines/lib/saving.py`](diffhunk://#diff-d5cd5db5ed3039d582e8d3d07f73b7dbd5b9bb7f91ee17f1b91d45810c5b88c1R19-R20): Added a check to create the directory if it does not exist before saving the output file.

Addition of new tests:

* [`recsa/pipelines/lib/tests/test_saving.py`](diffhunk://#diff-04c4ecdf04535cc6f25d02955725d3c83494b3aa4dfc29fc9150e182e05da97cR86-R97): Added a new test `test_write_output_with_filename_only` to verify that the output file is created and the data is saved correctly when only a filename is provided.