### PR TITLE
Feature/cli

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -173,6 +173,20 @@ files = [
 ]
 
 [[package]]
+name = "click"
+version = "8.1.8"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
+    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -1606,4 +1620,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "965ad6eddd2345a5c27f95d7f475f439371b881ff4d38a7253279e61aa575d1b"
+content-hash = "ae45c4d87a517f0f8ac2aa673adfa2d5084cd99edf9dac1cead833a5392837bb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[project]
+name = "recsa"
+dynamic = ["version"]
+
 [tool.poetry]
 name = "recsa"
 version = "0.3.0"
@@ -29,3 +33,6 @@ sphinx = "^8.0.2"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[project.scripts]
+recsa = "recsa.cli.main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ types-pyyaml = "^6.0.12.20240917"
 pydantic = "^2.9.2"
 cachetools = "^5.5.0"
 types-cachetools = "^5.5.0.20240820"
+click = "^8.1.8"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.2"

--- a/recsa/cli/commands.py
+++ b/recsa/cli/commands.py
@@ -1,0 +1,14 @@
+import click
+
+from recsa.pipelines import enum_bond_subsets_pipeline
+
+
+@click.command()
+@click.option(
+    '--input', '-i', type=click.Path(exists=True), required=True, 
+    help='Input file path')
+@click.option(
+    '--output', '-o', type=click.Path(), required=True, 
+    help='Output file path')
+def run_bond_subset_pipeline(input, output):
+    enum_bond_subsets_pipeline(input, output)

--- a/recsa/cli/main.py
+++ b/recsa/cli/main.py
@@ -1,0 +1,14 @@
+import click
+
+from recsa.cli.commands import run_bond_subset_pipeline
+
+
+@click.group()
+def main():
+    """RECSA CLI"""
+    pass
+
+main.add_command(run_bond_subset_pipeline, name='enum-bond-subsets')
+
+if __name__ == '__main__':
+    main()

--- a/recsa/cli/tests/test_bondset_enumeration.py
+++ b/recsa/cli/tests/test_bondset_enumeration.py
@@ -1,0 +1,39 @@
+import os
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from recsa.cli.commands import run_bond_subset_pipeline
+
+
+def test_cli_command_a(tmp_path):
+    runner = CliRunner()
+
+    INPUT_DATA = {
+        'bonds': [1, 2, 3, 4],
+        'adj_bonds': {
+            1: {2},
+            2: {1, 3},
+            3: {2, 4},
+            4: {3}}
+        }
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        input_path = os.path.join(td, 'input.yaml')
+        output_path = os.path.join(td, 'output.yaml')
+
+        with open(input_path, 'w') as f:
+            yaml.safe_dump(INPUT_DATA, f)
+        
+        result = runner.invoke(
+            run_bond_subset_pipeline,
+            ['--input', input_path, '--output', output_path]
+        )
+
+        assert result.exit_code == 0
+        assert os.path.exists(output_path)
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])

--- a/recsa/cli/tests/test_main.py
+++ b/recsa/cli/tests/test_main.py
@@ -1,0 +1,41 @@
+import os
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from recsa.cli.main import main
+
+
+def test_main(tmp_path):
+    runner = CliRunner()
+
+    INPUT_DATA = {
+        'bonds': [1, 2, 3, 4],
+        'adj_bonds': {
+            1: {2},
+            2: {1, 3},
+            3: {2, 4},
+            4: {3}}
+        }
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        input_path = os.path.join(td, 'input.yaml')
+        output_path = os.path.join(td, 'output.yaml')
+
+        with open(input_path, 'w') as f:
+            yaml.safe_dump(INPUT_DATA, f)
+        
+        result = runner.invoke(
+            main,
+            [
+                'enum-bond-subsets', '--input', input_path, 
+                '--output', output_path]
+        )
+
+        assert result.exit_code == 0
+        assert os.path.exists(output_path)
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces a new CLI tool for the `recsa` project and adds the necessary dependencies and tests. The most important changes include the addition of the `click` library, the implementation of the CLI commands, and the corresponding tests.

### CLI Tool Implementation:

* [`recsa/cli/commands.py`](diffhunk://#diff-6072a1e48e56829533f6f647cec7986c8c3182d85118c8564ccafb73d7a2f0ecR1-R14): Added a new CLI command `run_bond_subset_pipeline` using the `click` library to handle input and output file paths and execute the `enum_bond_subsets_pipeline` function.
* [`recsa/cli/main.py`](diffhunk://#diff-4af3bf0b112be3175aecd49a387a5927c66373d1875e230363a8efd07303c396R1-R14): Created a main CLI entry point with a command group and registered the `run_bond_subset_pipeline` command.

### Dependency Management:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R27): Added `click` as a dependency and defined the project scripts to include the new CLI tool. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R27) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R36-R38)

### Testing:

* [`recsa/cli/tests/test_bondset_enumeration.py`](diffhunk://#diff-23c435ebb228025698410b8e7adbbd968a3e30a472f363458c06414bce43d7a1R1-R39): Added a test for the `run_bond_subset_pipeline` command, verifying that it correctly processes input and output files.
* [`recsa/cli/tests/test_main.py`](diffhunk://#diff-5959c8dd8d812378f45cdde07b3305907e395a2c32aeed87e1a8466a29f47608R1-R41): Added a test for the main CLI entry point, ensuring the `enum-bond-subsets` command works as expected.