### PR TITLE
Fix write_output function to use simple dump instead of safe_dump

### DIFF
--- a/recsa/pipelines/lib/saving.py
+++ b/recsa/pipelines/lib/saving.py
@@ -20,6 +20,6 @@ def write_output(
     if dir_:
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
     with open(output_path, 'w') as f:
-        yaml.safe_dump(data, f, default_flow_style=default_flow_style)
+        yaml.dump(data, f, default_flow_style=default_flow_style)
     if verbose:
         print(f'Successfully saved the results to "{output_path}".')


### PR DESCRIPTION
This pull request includes a small change to the `recsa/pipelines/lib/saving.py` file. The change modifies the `write_output` function to use `yaml.dump` instead of `yaml.safe_dump` for saving data to a file.

* [`recsa/pipelines/lib/saving.py`](diffhunk://#diff-d5cd5db5ed3039d582e8d3d07f73b7dbd5b9bb7f91ee17f1b91d45810c5b88c1L23-R23): Changed `yaml.safe_dump` to `yaml.dump` in the `write_output` function.