### PR TITLE
Refactor CLI commands to use arguments instead of options

### DIFF
--- a/recsa/cli/commands.py
+++ b/recsa/cli/commands.py
@@ -7,7 +7,7 @@ from recsa.pipelines import (bondsets_to_assemblies_pipeline,
 @click.command('enumerate-bond-subsets')
 @click.argument('input', type=click.Path(exists=True))
 @click.argument('output', type=click.Path())
-def run_enum_bond_subset_pipeline(input, output):
+def run_enum_bond_subsets_pipeline(input, output):
     """Enumerates bond subsets.
     
     \b

--- a/recsa/cli/commands.py
+++ b/recsa/cli/commands.py
@@ -4,26 +4,33 @@ from recsa.pipelines import (bondsets_to_assemblies_pipeline,
                              enum_bond_subsets_pipeline)
 
 
-@click.command()
-@click.option(
-    '--input', '-i', type=click.Path(exists=True), required=True, 
-    help='Input file path')
-@click.option(
-    '--output', '-o', type=click.Path(), required=True, 
-    help='Output file path')
-def run_bond_subset_pipeline(input, output):
+@click.command('enumerate-bond-subsets')
+@click.argument('input', type=click.Path(exists=True))
+@click.argument('output', type=click.Path())
+def run_enum_bond_subset_pipeline(input, output):
+    """Enumerates bond subsets.
+    
+    \b
+    Parameters
+    ----------
+    - INPUT: Path to input file.
+    - OUTPUT: Path to output file.
+    """
     enum_bond_subsets_pipeline(input, output)
 
 
-@click.command()
-@click.option(
-    '--bondsets', '-b', type=click.Path(exists=True), required=True,
-    help='Path to bond subsets file')
-@click.option(
-    '--structure', '-s', type=click.Path(exists=True), required=True,
-    help='Path to structure data file')
-@click.option(
-    '--output', '-o', type=click.Path(), required=True,
-    help='Output file path')
-def run_bondset_to_assembly_pipeline(bondsets, structure, output):
+@click.command('bondsets-to-assemblies')
+@click.argument('bondsets', type=click.Path(exists=True))
+@click.argument('structure', type=click.Path(exists=True))
+@click.argument('output', type=click.Path())
+def run_bondsets_to_assemblies_pipeline(bondsets, structure, output):
+    """Converts bondsets to assemblies.
+    
+    \b
+    Parameters
+    ----------
+    - BONDSETS: Path to input file of bond subsets.
+    - STRUCTURE: Path to input file of structure.
+    - OUTPUT: Path to output file.
+    """
     bondsets_to_assemblies_pipeline(bondsets, structure, output)

--- a/recsa/cli/main.py
+++ b/recsa/cli/main.py
@@ -1,7 +1,7 @@
 import click
 
-from recsa.cli.commands import (run_bond_subset_pipeline,
-                                run_bondset_to_assembly_pipeline)
+from recsa.cli.commands import (run_bondsets_to_assemblies_pipeline,
+                                run_enum_bond_subset_pipeline)
 
 
 @click.group()
@@ -9,8 +9,8 @@ def main():
     """RECSA CLI"""
     pass
 
-main.add_command(run_bond_subset_pipeline, name='enum-bond-subsets')
-main.add_command(run_bondset_to_assembly_pipeline, name='bondset-to-assembly')
+main.add_command(run_enum_bond_subset_pipeline)
+main.add_command(run_bondsets_to_assemblies_pipeline)
 
 if __name__ == '__main__':
     main()

--- a/recsa/cli/main.py
+++ b/recsa/cli/main.py
@@ -1,7 +1,7 @@
 import click
 
 from recsa.cli.commands import (run_bondsets_to_assemblies_pipeline,
-                                run_enum_bond_subset_pipeline)
+                                run_enum_bond_subsets_pipeline)
 
 
 @click.group()
@@ -9,7 +9,7 @@ def main():
     """RECSA CLI"""
     pass
 
-main.add_command(run_enum_bond_subset_pipeline)
+main.add_command(run_enum_bond_subsets_pipeline)
 main.add_command(run_bondsets_to_assemblies_pipeline)
 
 if __name__ == '__main__':

--- a/recsa/cli/tests/test_bondset_enumeration.py
+++ b/recsa/cli/tests/test_bondset_enumeration.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 from click.testing import CliRunner
 
-from recsa.cli.commands import run_bond_subset_pipeline
+from recsa.cli.commands import run_enum_bond_subset_pipeline
 
 
 def test_cli_command_a(tmp_path):
@@ -16,8 +16,15 @@ def test_cli_command_a(tmp_path):
             1: {2},
             2: {1, 3},
             3: {2, 4},
-            4: {3}}
+            4: {3},
+        },
+        'sym_maps': {
+            'C2': {1: 4, 2: 3, 3: 2, 4: 1}
         }
+    }
+    
+    EXPECTED = [[1], [2], [1, 2], [2, 3], [1, 2, 3], [1, 2, 3, 4]]
+
 
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
         input_path = os.path.join(td, 'input.yaml')
@@ -27,12 +34,17 @@ def test_cli_command_a(tmp_path):
             yaml.safe_dump(INPUT_DATA, f)
         
         result = runner.invoke(
-            run_bond_subset_pipeline,
-            ['--input', input_path, '--output', output_path]
+            run_enum_bond_subset_pipeline,
+            [input_path, output_path]
         )
 
         assert result.exit_code == 0
         assert os.path.exists(output_path)
+
+        with open(output_path, 'r') as f:
+            actual_output = yaml.safe_load(f)
+
+        assert actual_output == EXPECTED
 
 
 if __name__ == '__main__':

--- a/recsa/cli/tests/test_bondset_enumeration.py
+++ b/recsa/cli/tests/test_bondset_enumeration.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 from click.testing import CliRunner
 
-from recsa.cli.commands import run_enum_bond_subset_pipeline
+from recsa.cli.commands import run_enum_bond_subsets_pipeline
 
 
 def test_cli_command_a(tmp_path):
@@ -34,7 +34,7 @@ def test_cli_command_a(tmp_path):
             yaml.safe_dump(INPUT_DATA, f)
         
         result = runner.invoke(
-            run_enum_bond_subset_pipeline,
+            run_enum_bond_subsets_pipeline,
             [input_path, output_path]
         )
 

--- a/recsa/cli/tests/test_bondset_to_assembly.py
+++ b/recsa/cli/tests/test_bondset_to_assembly.py
@@ -5,7 +5,7 @@ import yaml
 from click.testing import CliRunner
 
 from recsa import Assembly
-from recsa.cli.commands import run_bondset_to_assembly_pipeline
+from recsa.cli.commands import run_bondsets_to_assemblies_pipeline
 
 
 @pytest.fixture
@@ -73,9 +73,8 @@ def test_cli_command_a(tmp_path, bondsets_data, structure_data, expected_assembl
             yaml.safe_dump(structure_data, f)
         
         result = runner.invoke(
-            run_bondset_to_assembly_pipeline,
-            ['--bondsets', bondset_path, '--structure', structure_path, 
-             '--output', output_path]
+            run_bondsets_to_assemblies_pipeline,
+            [bondset_path, structure_path, output_path]
         )
 
         assert result.exit_code == 0

--- a/recsa/cli/tests/test_main.py
+++ b/recsa/cli/tests/test_main.py
@@ -17,8 +17,13 @@ def test_enum_bond_subsets(tmp_path):
             1: {2},
             2: {1, 3},
             3: {2, 4},
-            4: {3}}
+            4: {3}},
+        'sym_maps': {
+            'C2': {1: 4, 2: 3, 3: 2, 4: 1}
         }
+    }
+
+    EXPECTED = [[1], [2], [1, 2], [2, 3], [1, 2, 3], [1, 2, 3, 4]]
 
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
         input_path = os.path.join(td, 'input.yaml')
@@ -29,19 +34,22 @@ def test_enum_bond_subsets(tmp_path):
         
         result = runner.invoke(
             main,
-            [
-                'enum-bond-subsets', '--input', input_path, 
-                '--output', output_path]
+            ['enumerate-bond-subsets', input_path, output_path]
         )
 
         assert result.exit_code == 0
         assert os.path.exists(output_path)
 
+        with open(output_path, 'r') as f:
+            actual_output = yaml.safe_load(f)
+
+        assert actual_output == EXPECTED
+
 
 def test_bondsets_to_assemblies(tmp_path):
     runner = CliRunner()
 
-    bondsets_data = {
+    BONDSETS_DATA = {
         0: [1],
         1: [1, 2],
         2: [2, 3],
@@ -49,7 +57,7 @@ def test_bondsets_to_assemblies(tmp_path):
         4: [1, 2, 3, 4]
     }
 
-    structure_data = {
+    STRUCTURE_DATA = {
         'comp_id_to_kind': {
             'M1': 'M',
             'M2': 'M',
@@ -65,7 +73,7 @@ def test_bondsets_to_assemblies(tmp_path):
         }
     }
 
-    expected_assemblies = {
+    EXPECTED = {
         0: Assembly({'L1': 'L', 'M1': 'M'}, [('L1.b', 'M1.a')]),
         1: Assembly(
             {'L1': 'L', 'M1': 'M', 'L2': 'L'},
@@ -88,16 +96,15 @@ def test_bondsets_to_assemblies(tmp_path):
         output_path = os.path.join(td, 'output.yaml')
 
         with open(bondsets_path, 'w') as f:
-            yaml.safe_dump(bondsets_data, f)
+            yaml.safe_dump(BONDSETS_DATA, f)
 
         with open(structure_data_path, 'w') as f:
-            yaml.safe_dump(structure_data, f)
+            yaml.safe_dump(STRUCTURE_DATA, f)
 
         result = runner.invoke(
             main,
-            [
-                'bondset-to-assembly', '--bondsets', bondsets_path, 
-                '--structure', structure_data_path, '--output', output_path]
+            ['bondsets-to-assemblies', bondsets_path, structure_data_path, 
+             output_path]
         )
 
         assert result.exit_code == 0
@@ -106,7 +113,7 @@ def test_bondsets_to_assemblies(tmp_path):
         with open(output_path, 'r') as f:
             actual_output = yaml.safe_load(f)
         
-        assert actual_output == expected_assemblies
+        assert actual_output == EXPECTED
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request includes several changes to the `recsa` CLI commands and their corresponding tests. The main focus is on renaming functions and updating the command-line interface to use arguments instead of options. Additionally, the tests have been updated to reflect these changes and include new expected outputs for validation.

### CLI Command Updates:
* Renamed `run_bond_subset_pipeline` to `run_enum_bond_subset_pipeline` and updated the command to use arguments instead of options.
* Renamed `run_bondset_to_assembly_pipeline` to `run_bondsets_to_assemblies_pipeline` and updated the command to use arguments instead of options.

### Main CLI Entry Point:
* Updated the main CLI entry point to use the new command names and removed the explicit naming of commands.

### Test Updates:
* Updated `test_bondset_enumeration.py` to use the new function name `run_enum_bond_subset_pipeline` and added validation for expected output. [[1]](diffhunk://#diff-23c435ebb228025698410b8e7adbbd968a3e30a472f363458c06414bce43d7a1L7-R7) [[2]](diffhunk://#diff-23c435ebb228025698410b8e7adbbd968a3e30a472f363458c06414bce43d7a1L19-R27) [[3]](diffhunk://#diff-23c435ebb228025698410b8e7adbbd968a3e30a472f363458c06414bce43d7a1L30-R48)
* Updated `test_bondset_to_assembly.py` to use the new function name `run_bondsets_to_assemblies_pipeline`. [[1]](diffhunk://#diff-a43b2e1fe084c9f409c5ba14a3a02688b25fd3aa981abba918bececacb062f80L8-R8) [[2]](diffhunk://#diff-a43b2e1fe084c9f409c5ba14a3a02688b25fd3aa981abba918bececacb062f80L76-R77)
* Updated `test_main.py` to use the new command names and added validation for expected outputs. [[1]](diffhunk://#diff-5959c8dd8d812378f45cdde07b3305907e395a2c32aeed87e1a8466a29f47608L20-R26) [[2]](diffhunk://#diff-5959c8dd8d812378f45cdde07b3305907e395a2c32aeed87e1a8466a29f47608L32-R60) [[3]](diffhunk://#diff-5959c8dd8d812378f45cdde07b3305907e395a2c32aeed87e1a8466a29f47608L68-R76) [[4]](diffhunk://#diff-5959c8dd8d812378f45cdde07b3305907e395a2c32aeed87e1a8466a29f47608L91-R107) [[5]](diffhunk://#diff-5959c8dd8d812378f45cdde07b3305907e395a2c32aeed87e1a8466a29f47608L109-R116)