### PR TITLE
Typing/generic

### DIFF
--- a/recsa/duplicate_exclusion/lib/grouping_by_hash.py
+++ b/recsa/duplicate_exclusion/lib/grouping_by_hash.py
@@ -1,16 +1,18 @@
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Hashable, Mapping
+from typing import TypeVar
 
 from recsa import Assembly, Component, calc_graph_hash_of_assembly
 
 __all__ = ['group_assemblies_by_hash']
 
 
+_T = TypeVar('_T', bound=Hashable)
 
 def group_assemblies_by_hash(
-        id_to_assembly: Mapping[int, Assembly],
+        id_to_assembly: Mapping[_T, Assembly],
         component_structures: Mapping[str, Component]
-        ) -> dict[str, set[int]]:
+        ) -> dict[str, set[_T]]:
     # Group by hash
     hash_to_ids = defaultdict(set)
     for id_, assembly in id_to_assembly.items():

--- a/recsa/duplicate_exclusion/lib/grouping_by_isomorphism.py
+++ b/recsa/duplicate_exclusion/lib/grouping_by_isomorphism.py
@@ -1,5 +1,6 @@
-from collections.abc import Iterable, Mapping
+from collections.abc import Hashable, Iterable, Mapping
 from itertools import combinations
+from typing import TypeVar, cast
 
 from networkx.utils import UnionFind
 
@@ -9,24 +10,24 @@ from .grouping_by_hash import group_assemblies_by_hash
 
 __all__ = ['group_assemblies_by_isomorphism']
 
-
+_T = TypeVar('_T', bound=Hashable)
 
 def group_assemblies_by_isomorphism(
-        id_to_assembly: Mapping[int, Assembly],
+        id_to_assembly: Mapping[_T, Assembly],
         component_structures: Mapping[str, Component]
-        ) -> dict[int, set[int]]:
+        ) -> dict[_T, set[_T]]:
     """Group duplicates by assembly isomorphism.
 
     Parameters
     ----------
-    id_to_grpah : Mapping[str, Assembly]
+    id_to_assembly : Mapping[_T, Assembly]
         A mapping from IDs to assemblies.
     component_structures : Mapping[str, ComponentStructure]
         A mapping from component kinds to component structures.
 
     Returns
     -------
-    dict[str, set[str]]
+    dict[_T, set[_T]]
         A mapping from unique IDs to sets of duplicate IDs.
         Unique IDs are the minimum IDs in each group.
         Duplicate IDs include the unique IDs themselves.
@@ -47,6 +48,6 @@ def group_assemblies_by_isomorphism(
                     component_structures):
                 uf.union(id1, id2)
 
-    grouped_ids: Iterable[set[int]] = uf.to_sets()
+    grouped_ids = cast(Iterable[set[_T]], uf.to_sets())
     unique_id_to_ids = {min(ids): ids for ids in grouped_ids}
     return unique_id_to_ids


### PR DESCRIPTION
This pull request includes changes to the `recsa/duplicate_exclusion` library to enhance type safety and generalize the grouping functions. The most important changes involve updating type annotations to use a generic type variable and ensuring compatibility with hashable types.

Enhancements to type safety and generalization:

* [`recsa/duplicate_exclusion/lib/grouping_by_hash.py`](diffhunk://#diff-2b76f15e941146629cca52e6075727944cf21f29f6405917b5c87ba6bd9e9f35L2-R15): Introduced a type variable `_T` bound to `Hashable` for the `id_to_assembly` parameter and updated the return type to use `_T` instead of `int`.
* [`recsa/duplicate_exclusion/lib/grouping_by_isomorphism.py`](diffhunk://#diff-6c306c0edfdba6044ef7409251f3becdc5a27ad62a4a2d63a0ccd6526bc9f638L1-R3): Added a type variable `_T` bound to `Hashable` for the `id_to_assembly` parameter and updated the return type to use `_T` instead of `int`. [[1]](diffhunk://#diff-6c306c0edfdba6044ef7409251f3becdc5a27ad62a4a2d63a0ccd6526bc9f638L1-R3) [[2]](diffhunk://#diff-6c306c0edfdba6044ef7409251f3becdc5a27ad62a4a2d63a0ccd6526bc9f638L12-R30)
* [`recsa/duplicate_exclusion/lib/grouping_by_isomorphism.py`](diffhunk://#diff-6c306c0edfdba6044ef7409251f3becdc5a27ad62a4a2d63a0ccd6526bc9f638L50-R51): Used `cast` to ensure the type of `grouped_ids` is correctly interpreted as `Iterable[set[_T]]`.