### PR TITLE
Update type hints in find_unique_assemblies to use Sequence

### DIFF
--- a/recsa/duplicate_exclusion/core.py
+++ b/recsa/duplicate_exclusion/core.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterator, Mapping, Sequence
 
 from recsa import Assembly, Component, calc_graph_hash_of_assembly
 
@@ -9,7 +9,7 @@ __all__ = ['find_unique_assemblies']
 
 
 def find_unique_assemblies(
-        assemblies: Iterable[Assembly],
+        assemblies: Sequence[Assembly],
         component_structures: Mapping[str, Component]
         ) -> Iterator[Assembly]:
     """Get unique assemblies.
@@ -24,9 +24,9 @@ def find_unique_assemblies(
 
     Parameters
     ----------
-    assemblies : Iterable[tuple[str, Assembly]]
-        An iterable of tuples of IDs and assemblies.
-    component_structures : Mapping[str, ComponentStructure]
+    assemblies : Sequence[Assembly]
+        A sequence of assemblies.
+    component_structures : Mapping[str, Component]
         A mapping from component kinds to component structures.
 
     Yields


### PR DESCRIPTION
This pull request includes changes to the `recsa/duplicate_exclusion/core.py` file to improve type annotations and update the parameter types for the `find_unique_assemblies` function.

Changes to type annotations and parameter types:

* [`recsa/duplicate_exclusion/core.py`](diffhunk://#diff-96ac26e052151978df137a86e503ae145be32f42dad3eb04d9b662f8e9465891L2-R2): Updated the import statement to use `Sequence` instead of `Iterable` from `collections.abc`.
* [`recsa/duplicate_exclusion/core.py`](diffhunk://#diff-96ac26e052151978df137a86e503ae145be32f42dad3eb04d9b662f8e9465891L12-R12): Changed the parameter type for `assemblies` in the `find_unique_assemblies` function from `Iterable` to `Sequence`.
* [`recsa/duplicate_exclusion/core.py`](diffhunk://#diff-96ac26e052151978df137a86e503ae145be32f42dad3eb04d9b662f8e9465891L27-R29): Updated the docstring for the `assemblies` parameter in the `find_unique_assemblies` function to reflect the change from `Iterable` to `Sequence`.