### PR TITLE
Fix log message in bondsets_to_assemblies_pipeline

### DIFF
--- a/recsa/pipelines/bondset_to_assembly.py
+++ b/recsa/pipelines/bondset_to_assembly.py
@@ -31,7 +31,7 @@ def bondsets_to_assemblies_pipeline(
     
     # Main process
     if verbose:
-        print('Enumerating bond subsets...')
+        print('Converting bondsets to assemblies...')
     
     id_to_assembly = {
         id_: convert_bondset_to_assembly(


### PR DESCRIPTION
This pull request includes a small but important change to the `bondsets_to_assemblies_pipeline` function in the `recsa/pipelines/bondset_to_assembly.py` file. The change updates a print statement to provide a clearer description of the process being executed.

* [`recsa/pipelines/bondset_to_assembly.py`](diffhunk://#diff-f70a73db8b73bee7401937572173537330be686abc41d7fb6a34bb7e9057ae5dL34-R34): Updated the print statement from 'Enumerating bond subsets...' to 'Converting bondsets to assemblies...' to better reflect the current operation.