### PR TITLE
bump version to 0.6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "recsa"
-version = "0.6.2"
+version = "0.6.3"
 description = "Reaction Explorer for Coordination Self-Assembly"
 authors = ["neji-craftsman <142223934+neji-craftsman@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change updates the version number of the `recsa` project from `0.6.2` to `0.6.3`.