### PR TITLE
Add duplicate exclusion pipeline and corresponding tests

### DIFF
--- a/recsa/pipelines/__init__.py
+++ b/recsa/pipelines/__init__.py
@@ -1,2 +1,3 @@
 from .bondset_enumeration import enum_bond_subsets_pipeline
 from .bondset_to_assembly import bondsets_to_assemblies_pipeline
+from .duplicate_exclusion import find_unique_assemblies_pipeline

--- a/recsa/pipelines/duplicate_exclusion.py
+++ b/recsa/pipelines/duplicate_exclusion.py
@@ -1,0 +1,47 @@
+import os
+from collections.abc import Hashable, Mapping
+from typing import TypeVar
+
+from recsa import Assembly, Component, group_assemblies_by_isomorphism
+from recsa.pipelines.lib import read_file, write_output
+
+_T = TypeVar('_T', bound=Hashable)
+
+
+
+# ============================================================
+# Main Process
+# ============================================================
+
+def find_unique_assemblies_pipeline(
+        assemblies_path: os.PathLike | str,
+        components_path: os.PathLike | str,
+        output_path: os.PathLike | str,
+        *,
+        overwrite: bool = False,
+        verbose: bool = False
+        ) -> None:
+    # Input
+    id_to_assembly: Mapping[Hashable, Assembly] = read_file(
+        assemblies_path, verbose=verbose)
+    components: Mapping[str, Component] = read_file(
+        components_path, verbose=verbose)
+    
+    # Main process
+    if verbose:
+        print('Enumerating unique assemblies...')
+    
+    unique_id_to_dup_ids = group_assemblies_by_isomorphism(
+        id_to_assembly, components)
+    id_to_unique_assembly = {
+        unique_id: id_to_assembly[unique_id]
+        for unique_id in unique_id_to_dup_ids
+    }
+    
+    if verbose:
+        print('Finished enumeration.')
+    
+    # Output
+    write_output(
+        output_path, id_to_unique_assembly, 
+        overwrite=overwrite, verbose=verbose)

--- a/recsa/pipelines/tests/test_duplicate_exclusion.py
+++ b/recsa/pipelines/tests/test_duplicate_exclusion.py
@@ -1,0 +1,141 @@
+import os
+
+import pytest
+import yaml
+
+from recsa import Assembly, Component
+from recsa.pipelines import find_unique_assemblies_pipeline
+
+
+@pytest.fixture
+def assemblies_data():
+    return {
+        0: Assembly({'L1': 'L', 'M1': 'M'}, [('L1.b', 'M1.a')]),
+        1: Assembly({'M1': 'M', 'L2': 'L'}, [('M1.b', 'L2.a')]),  # Duplicate
+        2: Assembly(
+            {'L1': 'L', 'M1': 'M', 'L2': 'L'},
+            [('L1.b', 'M1.a'), ('M1.b', 'L2.a')]),
+        3: Assembly(
+            {'M1': 'M', 'L2': 'L', 'M2': 'M'},
+            [('M1.b', 'L2.a'), ('L2.b', 'M2.a')]),
+        4: Assembly(
+            {'L1': 'L', 'M1': 'M', 'L2': 'L', 'M2': 'M'},
+            [('L1.b', 'M1.a'), ('M1.b', 'L2.a'), ('L2.b', 'M2.a')]),
+        5: Assembly(
+            {'L1': 'L', 'M1': 'M', 'L2': 'L', 'M2': 'M', 'L3': 'L'},
+            [('L1.b', 'M1.a'), ('M1.b', 'L2.a'), ('L2.b', 'M2.a'), 
+             ('M2.b', 'L3.a')])
+    }
+
+@pytest.fixture
+def components_data():
+    return {
+        'L': Component(['a', 'b']),
+        'M': Component(['a', 'b'])
+    }
+
+@pytest.fixture
+def expected_unique_assemblies(assemblies_data):
+    return {
+        0: assemblies_data[0],
+        2: assemblies_data[2],
+        3: assemblies_data[3],
+        4: assemblies_data[4],
+        5: assemblies_data[5]
+    }
+
+def test_find_unique_assemblies_pipeline(
+        tmp_path, assemblies_data, components_data, 
+        expected_unique_assemblies):
+    assemblies_path = tmp_path / 'assemblies.yaml'
+    components_path = tmp_path / 'components.yaml'
+    output_path = tmp_path / 'output.yaml'
+
+    with open(assemblies_path, 'w') as f:
+        yaml.dump(assemblies_data, f)
+    
+    with open(components_path, 'w') as f:
+        yaml.dump(components_data, f)
+
+    # Run the pipeline
+    find_unique_assemblies_pipeline(
+        assemblies_path=str(assemblies_path),
+        components_path=str(components_path),
+        output_path=str(output_path),
+    )
+
+    with open(output_path, 'r') as f:
+        output_data = yaml.safe_load(f)
+
+    assert output_data == expected_unique_assemblies
+
+
+def test_find_unique_assemblies_pipeline_overwrite(
+        tmp_path, assemblies_data, components_data, 
+        expected_unique_assemblies):
+    assemblies_path = tmp_path / 'assemblies.yaml'
+    components_path = tmp_path / 'components.yaml'
+    output_path = tmp_path / 'output.yaml'
+
+    with open(assemblies_path, 'w') as f:
+        yaml.dump(assemblies_data, f)
+    
+    with open(components_path, 'w') as f:
+        yaml.dump(components_data, f)
+    
+    # Create an initial output file
+    with open(output_path, 'w') as f:
+        yaml.dump({'initial': 'data'}, f)
+
+    # Run the pipeline with overwrite
+    find_unique_assemblies_pipeline(
+        assemblies_path=str(assemblies_path),
+        components_path=str(components_path),
+        output_path=str(output_path),
+        overwrite=True
+    )
+
+    with open(output_path, 'r') as f:
+        output_data = yaml.safe_load(f)
+    
+    # Check that the initial data is gone
+    assert 'initial' not in output_data
+
+    assert output_data == expected_unique_assemblies
+
+
+def test_find_unique_assemblies_pipeline_no_overwrite(
+        tmp_path, assemblies_data, components_data):
+    assemblies_path = tmp_path / 'assemblies.yaml'
+    components_path = tmp_path / 'components.yaml'
+    output_path = tmp_path / 'output.yaml'
+
+    with open(assemblies_path, 'w') as f:
+        yaml.dump(assemblies_data, f)
+    
+    with open(components_path, 'w') as f:
+        yaml.dump(components_data, f)
+
+    # Create an initial output file
+    with open(output_path, 'w') as f:
+        yaml.dump({'initial': 'data'}, f)
+
+    # Run the pipeline without overwrite
+    with pytest.raises(FileExistsError):
+        find_unique_assemblies_pipeline(
+            assemblies_path=str(assemblies_path),
+            components_path=str(components_path),
+            output_path=str(output_path),
+            overwrite=False
+        )
+
+    with open(output_path, 'r') as f:
+        output_data = yaml.safe_load(f)
+
+    # Check that the initial data is still there
+    assert 'initial' in output_data
+    assert output_data['initial'] == 'data'
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces a new pipeline for finding unique assemblies and includes corresponding tests. The main changes involve adding a new function to the pipeline and creating tests to ensure its correctness.

### New Pipeline Functionality:

* Added `find_unique_assemblies_pipeline` function in `recsa/pipelines/duplicate_exclusion.py` to identify unique assemblies by grouping them based on isomorphism and writing the results to an output file.
* Updated `recsa/pipelines/__init__.py` to include the new `find_unique_assemblies_pipeline` function.

### Tests for New Functionality:

* Created `recsa/pipelines/tests/test_duplicate_exclusion.py` to test the `find_unique_assemblies_pipeline` function. This includes tests for basic functionality, overwrite behavior, and no-overwrite behavior.