### PR TITLE
Release/0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "recsa"
-version = "0.6.3"
+version = "0.6.4"
 description = "Reaction Explorer for Coordination Self-Assembly"
 authors = ["neji-craftsman <142223934+neji-craftsman@users.noreply.github.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "recsa"
-version = "0.6.4"
+version = "0.7.0"
 description = "Reaction Explorer for Coordination Self-Assembly"
 authors = ["neji-craftsman <142223934+neji-craftsman@users.noreply.github.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "recsa"
-version = "0.6.2"
+version = "0.6.3"
 description = "Reaction Explorer for Coordination Self-Assembly"
 authors = ["neji-craftsman <142223934+neji-craftsman@users.noreply.github.com>"]
 license = "MIT"

--- a/recsa/pipelines/__init__.py
+++ b/recsa/pipelines/__init__.py
@@ -1,2 +1,3 @@
 from .bondset_enumeration import enum_bond_subsets_pipeline
 from .bondset_to_assembly import bondsets_to_assemblies_pipeline
+from .duplicate_exclusion import find_unique_assemblies_pipeline

--- a/recsa/pipelines/duplicate_exclusion.py
+++ b/recsa/pipelines/duplicate_exclusion.py
@@ -1,0 +1,47 @@
+import os
+from collections.abc import Hashable, Mapping
+from typing import TypeVar
+
+from recsa import Assembly, Component, group_assemblies_by_isomorphism
+from recsa.pipelines.lib import read_file, write_output
+
+_T = TypeVar('_T', bound=Hashable)
+
+
+
+# ============================================================
+# Main Process
+# ============================================================
+
+def find_unique_assemblies_pipeline(
+        assemblies_path: os.PathLike | str,
+        components_path: os.PathLike | str,
+        output_path: os.PathLike | str,
+        *,
+        overwrite: bool = False,
+        verbose: bool = False
+        ) -> None:
+    # Input
+    id_to_assembly: Mapping[Hashable, Assembly] = read_file(
+        assemblies_path, verbose=verbose)
+    components: Mapping[str, Component] = read_file(
+        components_path, verbose=verbose)
+    
+    # Main process
+    if verbose:
+        print('Enumerating unique assemblies...')
+    
+    unique_id_to_dup_ids = group_assemblies_by_isomorphism(
+        id_to_assembly, components)
+    id_to_unique_assembly = {
+        unique_id: id_to_assembly[unique_id]
+        for unique_id in unique_id_to_dup_ids
+    }
+    
+    if verbose:
+        print('Finished enumeration.')
+    
+    # Output
+    write_output(
+        output_path, id_to_unique_assembly, 
+        overwrite=overwrite, verbose=verbose)

--- a/recsa/pipelines/tests/test_duplicate_exclusion.py
+++ b/recsa/pipelines/tests/test_duplicate_exclusion.py
@@ -1,0 +1,141 @@
+import os
+
+import pytest
+import yaml
+
+from recsa import Assembly, Component
+from recsa.pipelines import find_unique_assemblies_pipeline
+
+
+@pytest.fixture
+def assemblies_data():
+    return {
+        0: Assembly({'L1': 'L', 'M1': 'M'}, [('L1.b', 'M1.a')]),
+        1: Assembly({'M1': 'M', 'L2': 'L'}, [('M1.b', 'L2.a')]),  # Duplicate
+        2: Assembly(
+            {'L1': 'L', 'M1': 'M', 'L2': 'L'},
+            [('L1.b', 'M1.a'), ('M1.b', 'L2.a')]),
+        3: Assembly(
+            {'M1': 'M', 'L2': 'L', 'M2': 'M'},
+            [('M1.b', 'L2.a'), ('L2.b', 'M2.a')]),
+        4: Assembly(
+            {'L1': 'L', 'M1': 'M', 'L2': 'L', 'M2': 'M'},
+            [('L1.b', 'M1.a'), ('M1.b', 'L2.a'), ('L2.b', 'M2.a')]),
+        5: Assembly(
+            {'L1': 'L', 'M1': 'M', 'L2': 'L', 'M2': 'M', 'L3': 'L'},
+            [('L1.b', 'M1.a'), ('M1.b', 'L2.a'), ('L2.b', 'M2.a'), 
+             ('M2.b', 'L3.a')])
+    }
+
+@pytest.fixture
+def components_data():
+    return {
+        'L': Component(['a', 'b']),
+        'M': Component(['a', 'b'])
+    }
+
+@pytest.fixture
+def expected_unique_assemblies(assemblies_data):
+    return {
+        0: assemblies_data[0],
+        2: assemblies_data[2],
+        3: assemblies_data[3],
+        4: assemblies_data[4],
+        5: assemblies_data[5]
+    }
+
+def test_find_unique_assemblies_pipeline(
+        tmp_path, assemblies_data, components_data, 
+        expected_unique_assemblies):
+    assemblies_path = tmp_path / 'assemblies.yaml'
+    components_path = tmp_path / 'components.yaml'
+    output_path = tmp_path / 'output.yaml'
+
+    with open(assemblies_path, 'w') as f:
+        yaml.dump(assemblies_data, f)
+    
+    with open(components_path, 'w') as f:
+        yaml.dump(components_data, f)
+
+    # Run the pipeline
+    find_unique_assemblies_pipeline(
+        assemblies_path=str(assemblies_path),
+        components_path=str(components_path),
+        output_path=str(output_path),
+    )
+
+    with open(output_path, 'r') as f:
+        output_data = yaml.safe_load(f)
+
+    assert output_data == expected_unique_assemblies
+
+
+def test_find_unique_assemblies_pipeline_overwrite(
+        tmp_path, assemblies_data, components_data, 
+        expected_unique_assemblies):
+    assemblies_path = tmp_path / 'assemblies.yaml'
+    components_path = tmp_path / 'components.yaml'
+    output_path = tmp_path / 'output.yaml'
+
+    with open(assemblies_path, 'w') as f:
+        yaml.dump(assemblies_data, f)
+    
+    with open(components_path, 'w') as f:
+        yaml.dump(components_data, f)
+    
+    # Create an initial output file
+    with open(output_path, 'w') as f:
+        yaml.dump({'initial': 'data'}, f)
+
+    # Run the pipeline with overwrite
+    find_unique_assemblies_pipeline(
+        assemblies_path=str(assemblies_path),
+        components_path=str(components_path),
+        output_path=str(output_path),
+        overwrite=True
+    )
+
+    with open(output_path, 'r') as f:
+        output_data = yaml.safe_load(f)
+    
+    # Check that the initial data is gone
+    assert 'initial' not in output_data
+
+    assert output_data == expected_unique_assemblies
+
+
+def test_find_unique_assemblies_pipeline_no_overwrite(
+        tmp_path, assemblies_data, components_data):
+    assemblies_path = tmp_path / 'assemblies.yaml'
+    components_path = tmp_path / 'components.yaml'
+    output_path = tmp_path / 'output.yaml'
+
+    with open(assemblies_path, 'w') as f:
+        yaml.dump(assemblies_data, f)
+    
+    with open(components_path, 'w') as f:
+        yaml.dump(components_data, f)
+
+    # Create an initial output file
+    with open(output_path, 'w') as f:
+        yaml.dump({'initial': 'data'}, f)
+
+    # Run the pipeline without overwrite
+    with pytest.raises(FileExistsError):
+        find_unique_assemblies_pipeline(
+            assemblies_path=str(assemblies_path),
+            components_path=str(components_path),
+            output_path=str(output_path),
+            overwrite=False
+        )
+
+    with open(output_path, 'r') as f:
+        output_data = yaml.safe_load(f)
+
+    # Check that the initial data is still there
+    assert 'initial' in output_data
+    assert output_data['initial'] == 'data'
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request includes several changes to the `recsa` project, primarily focusing on adding a new pipeline for duplicate exclusion and updating the version. The most important changes include the addition of the `find_unique_assemblies_pipeline` function, its integration into the pipeline's `__init__.py`, and the corresponding tests for this new functionality.

### New Pipeline Functionality:
* [`recsa/pipelines/duplicate_exclusion.py`](diffhunk://#diff-ea0962ea6b85ff9785e7e32d71aaf3548f076dcf7f2189003bdd39ef5aa33793R1-R47): Added the `find_unique_assemblies_pipeline` function to identify and process unique assemblies, including reading input files, performing the main process, and writing output files.

### Integration:
* [`recsa/pipelines/__init__.py`](diffhunk://#diff-5face669fd17f99ef76de27fa11d6bfa3f654ab42e230ba63754047d4cb81fc6R3): Integrated the new `find_unique_assemblies_pipeline` function into the pipeline's module imports.

### Testing:
* [`recsa/pipelines/tests/test_duplicate_exclusion.py`](diffhunk://#diff-68cbfcc9a47959d830f33188bbba9c8368493965b35c8532348ee84ff0a2477aR1-R141): Added comprehensive tests for the `find_unique_assemblies_pipeline` function, including fixtures for test data and tests for both overwrite and non-overwrite scenarios.

### Version Update:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the project version from `0.6.4` to `0.7.0`.