### PR TITLE
Add bindsite capping pipeline and corresponding tests

### DIFF
--- a/recsa/pipelines/__init__.py
+++ b/recsa/pipelines/__init__.py
@@ -1,3 +1,4 @@
+from .bindsite_capping import cap_bindsites_pipeline
 from .bondset_enumeration import enum_bond_subsets_pipeline
 from .bondset_to_assembly import bondsets_to_assemblies_pipeline
 from .duplicate_exclusion import find_unique_assemblies_pipeline

--- a/recsa/pipelines/bindsite_capping.py
+++ b/recsa/pipelines/bindsite_capping.py
@@ -1,0 +1,55 @@
+import os
+from collections.abc import Hashable, Mapping
+from typing import TypedDict
+
+from recsa import Assembly, Component, cap_bindsites
+from recsa.pipelines.lib import read_file, write_output
+
+
+class CappingConfig(TypedDict):
+    target_component_kind: str
+    capping_component_kind: str
+    capping_bindsite: str
+
+
+# ============================================================
+# Main Process
+# ============================================================
+
+def cap_bindsites_pipeline(
+        assemblies_path: os.PathLike | str,
+        components_path: os.PathLike | str,
+        config_path: os.PathLike | str,
+        output_path: os.PathLike | str,
+        *,
+        overwrite: bool = False,
+        verbose: bool = False
+        ) -> None:
+    # Input
+    id_to_assembly: Mapping[Hashable, Assembly] = read_file(
+        assemblies_path, verbose=verbose)
+    components: Mapping[str, Component] = read_file(
+        components_path, verbose=verbose)
+    config: CappingConfig = read_file(
+        config_path, verbose=verbose)
+    
+    # Main process
+    if verbose:
+        print('Capping binding sites...')
+
+    capped_assemblies = {}
+    for id_, assembly in id_to_assembly.items():
+        capped_assemblies[id_] = cap_bindsites(
+            assembly, components, 
+            config['target_component_kind'],
+            config['capping_component_kind'],
+            config['capping_bindsite'],
+            copy=True)
+        
+    if verbose:
+        print('Capping completed.')
+    
+    # Output
+    write_output(
+        output_path, capped_assemblies, 
+        overwrite=overwrite, verbose=verbose)

--- a/recsa/pipelines/tests/test_bindsite_capping.py
+++ b/recsa/pipelines/tests/test_bindsite_capping.py
@@ -1,0 +1,135 @@
+import pytest
+import yaml
+
+from recsa import Assembly, Component, is_isomorphic
+from recsa.pipelines import cap_bindsites_pipeline
+
+
+@pytest.fixture
+def assemblies_data():
+    return {
+        0: Assembly({'M1': 'M'}),  # M1
+        1: Assembly({'L1': 'L', 'M1': 'M'}, [('L1.b', 'M1.a')]),  # L1--M1
+        2: Assembly(  # M1--L1--M2
+            {'M1': 'M', 'L1': 'L', 'M2': 'M'},
+            [('M1.b', 'L1.a'), ('L1.b', 'M2.a')]),
+    }
+
+
+@pytest.fixture
+def components_data():
+    return {
+        'L': Component(['a', 'b']),
+        'M': Component(['a', 'b']),
+        'X': Component(['a']),
+    }
+
+
+def test_add_X_on_M(
+        tmp_path, assemblies_data, components_data):
+    assemblies_path = tmp_path / 'assemblies.yaml'
+    components_path = tmp_path / 'components.yaml'
+    config_path = tmp_path / 'config.yaml'
+    output_path = tmp_path / 'output.yaml'
+
+    CONFIG_DATA = {
+        'target_component_kind': 'M',
+        'capping_component_kind': 'X',
+        'capping_bindsite': 'a'
+    }
+
+    EXPECTED_CAPPED_ASSEMBLIES = {
+        0: Assembly(  # X1--M1--X2
+            {'M1': 'M', 'X1': 'X', 'X2': 'X'}, 
+            [('X1.a', 'M1.a'), ('X2.a', 'M1.b')]),
+        1: Assembly(  # L1--M1--X1
+            {'L1': 'L', 'M1': 'M', 'X1': 'X'}, 
+            [('L1.b', 'M1.a'), ('X1.a', 'M1.b')]),
+        2: Assembly(  # X1--M1--L1--M2--X2
+            {'M1': 'M', 'L1': 'L', 'M2': 'M', 'X1': 'X', 'X2': 'X'}, 
+            [('X1.a', 'M1.a'), ('M1.b', 'L1.a'), ('L1.b', 'M2.a'), 
+             ('M2.b', 'X2.a')]),
+        }
+
+    with open(assemblies_path, 'w') as f:
+        yaml.dump(assemblies_data, f)
+    
+    with open(components_path, 'w') as f:
+        yaml.dump(components_data, f)
+    
+    with open(config_path, 'w') as f:
+        yaml.dump(CONFIG_DATA, f)
+
+    # Run the pipeline
+    cap_bindsites_pipeline(
+        assemblies_path=str(assemblies_path),
+        components_path=str(components_path),
+        config_path=str(config_path),
+        output_path=str(output_path),
+    )
+
+    with open(output_path, 'r') as f:
+        output_data = yaml.safe_load(f)
+
+    assert output_data.keys() == EXPECTED_CAPPED_ASSEMBLIES.keys()
+    for assembly_id, expected_assembly in EXPECTED_CAPPED_ASSEMBLIES.items():
+        assert is_isomorphic(
+            output_data[assembly_id], expected_assembly,
+            components_data)
+
+
+def test_add_L_on_M(
+        tmp_path, assemblies_data, components_data):
+    assemblies_path = tmp_path / 'assemblies.yaml'
+    components_path = tmp_path / 'components.yaml'
+    config_path = tmp_path / 'config.yaml'
+    output_path = tmp_path / 'output.yaml'
+
+    CONFIG_DATA = {
+        'target_component_kind': 'M',
+        'capping_component_kind': 'L',
+        'capping_bindsite': 'a'
+    }
+
+    EXPECTED_CAPPED_ASSEMBLIES = {
+        0: Assembly(  # L1--M1--L2
+            {'M1': 'M', 'L1': 'L', 'L2': 'L'}, 
+            [('L1.a', 'M1.a'), ('L2.a', 'M1.b')]),
+        1: Assembly(  # L1--M1--L2
+            {'L1': 'L', 'M1': 'M', 'L2': 'L'}, 
+            [('L1.b', 'M1.a'), ('L2.a', 'M1.b')]),
+        2: Assembly(  # L1--M1--L2--M2--L3
+            {'M1': 'M', 'L1': 'L', 'L2': 'L', 'M2': 'M', 'L3': 'L'},
+            [('L1.a', 'M1.a'), ('L2.a', 'M1.b'), ('L2.b', 'M2.a'),
+             ('L3.a', 'M2.b')]),
+        }
+
+    with open(assemblies_path, 'w') as f:
+        yaml.dump(assemblies_data, f)
+    
+    with open(components_path, 'w') as f:
+        yaml.dump(components_data, f)
+    
+    with open(config_path, 'w') as f:
+        yaml.dump(CONFIG_DATA, f)
+
+    # Run the pipeline
+    cap_bindsites_pipeline(
+        assemblies_path=str(assemblies_path),
+        components_path=str(components_path),
+        config_path=str(config_path),
+        output_path=str(output_path),
+    )
+
+    with open(output_path, 'r') as f:
+        output_data = yaml.safe_load(f)
+
+    assert output_data.keys() == EXPECTED_CAPPED_ASSEMBLIES.keys()
+    for assembly_id, expected_assembly in EXPECTED_CAPPED_ASSEMBLIES.items():
+        assert is_isomorphic(
+            output_data[assembly_id], expected_assembly,
+            components_data)
+        
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces a new feature to cap binding sites in assemblies and includes the necessary pipeline, configuration, and tests. The most important changes are the addition of the `cap_bindsites_pipeline` function, the creation of the `CappingConfig` class, and the implementation of tests for the new pipeline.

New feature implementation:

* [`recsa/pipelines/__init__.py`](diffhunk://#diff-5face669fd17f99ef76de27fa11d6bfa3f654ab42e230ba63754047d4cb81fc6R1): Added import for the new `cap_bindsites_pipeline` function.
* [`recsa/pipelines/bindsite_capping.py`](diffhunk://#diff-40a529368454e04b4a9906e0d52865dafd67de9c9e639b53e1340c707a6bcf73R1-R55): Implemented the `cap_bindsites_pipeline` function which reads input files, processes the capping of binding sites, and writes the output. Introduced the `CappingConfig` class for configuration.

Testing:

* [`recsa/pipelines/tests/test_bindsite_capping.py`](diffhunk://#diff-bee7ffcc646b71f09c8434d404a57f7b9048ae54e4f5486b326000fe431ee694R1-R135): Added tests for the `cap_bindsites_pipeline` function using pytest. The tests cover different scenarios for capping binding sites with different components.