### PR TITLE
Update/saving message header

### DIFF
--- a/recsa/pipelines/bindsite_capping.py
+++ b/recsa/pipelines/bindsite_capping.py
@@ -52,4 +52,5 @@ def cap_bindsites_pipeline(
     # Output
     write_output(
         output_path, capped_assemblies, 
-        overwrite=overwrite, verbose=verbose)
+        overwrite=overwrite, verbose=verbose,
+        header='Capped assemblies')

--- a/recsa/pipelines/bondset_enumeration.py
+++ b/recsa/pipelines/bondset_enumeration.py
@@ -144,7 +144,8 @@ def enum_bond_subsets_pipeline(
     # Output
     formatted_result = sort_bond_subsets(result)
     write_output(
-        output_path, formatted_result, overwrite=overwrite, verbose=verbose)
+        output_path, formatted_result, overwrite=overwrite, verbose=verbose,
+        header='Enumerated bond subsets')
 
 
 # ============================================================

--- a/recsa/pipelines/bondset_to_assembly.py
+++ b/recsa/pipelines/bondset_to_assembly.py
@@ -44,7 +44,8 @@ def bondsets_to_assemblies_pipeline(
     
     # Output
     write_output(
-        output_path, id_to_assembly, overwrite=overwrite, verbose=verbose)
+        output_path, id_to_assembly, overwrite=overwrite, verbose=verbose,
+        header='Converted assemblies')
 
 
 # ============================================================

--- a/recsa/pipelines/duplicate_exclusion.py
+++ b/recsa/pipelines/duplicate_exclusion.py
@@ -44,4 +44,5 @@ def find_unique_assemblies_pipeline(
     # Output
     write_output(
         output_path, id_to_unique_assembly, 
-        overwrite=overwrite, verbose=verbose)
+        overwrite=overwrite, verbose=verbose,
+        header='Unique assemblies')

--- a/recsa/pipelines/lib/saving.py
+++ b/recsa/pipelines/lib/saving.py
@@ -9,7 +9,8 @@ def write_output(
         *,
         overwrite: bool = False,
         default_flow_style: bool | None = None,
-        verbose: bool = False
+        verbose: bool = False,
+        header: str | None = None,
         ) -> None:
     """Write the output data to a file using YAML format."""
     if not overwrite and os.path.exists(output_path):
@@ -22,4 +23,7 @@ def write_output(
     with open(output_path, 'w') as f:
         yaml.dump(data, f, default_flow_style=default_flow_style)
     if verbose:
-        print(f'Successfully saved the results to "{output_path}".')
+        if header:
+            print(f'{header}: Successfully saved to "{output_path}".')
+        else:
+            print(f'Successfully saved to "{output_path}".')

--- a/recsa/pipelines/lib/tests/test_saving.py
+++ b/recsa/pipelines/lib/tests/test_saving.py
@@ -95,5 +95,16 @@ def test_write_output_with_filename_only(tmp_path):
     assert saved_data == data
 
 
+def test_header_with_verbose(tmp_path, capsys):
+    output_path = tmp_path / "output.yaml"
+    data = {"key": "value"}
+    header = "Test Header"
+    
+    write_output(output_path, data, verbose=True, header=header)
+    
+    captured = capsys.readouterr()
+    assert f'{header}: Successfully saved to "{output_path}".' in captured.out
+
+
 if __name__ == '__main__':
     pytest.main(['-v', __file__])

--- a/recsa/pipelines/tests/test_bondset_enumeration/test_enum_bond_subsets_pipline.py
+++ b/recsa/pipelines/tests/test_bondset_enumeration/test_enum_bond_subsets_pipline.py
@@ -131,7 +131,7 @@ def test_verbose_true(tmp_path, capsys):
     assert f'Number of bond subsets: 10' in captured.out
     assert f'Saving the results to "{output_path}"...' in captured.out
     assert (
-        f'Successfully saved the results to "{output_path}"' in captured.out)
+        f'Successfully saved to "{output_path}"' in captured.out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces enhancements to the output logging functionality across several pipeline functions by adding a `header` parameter to the `write_output` function. Additionally, corresponding unit tests have been updated to verify the new behavior.

Enhancements to output logging:

* [`recsa/pipelines/bindsite_capping.py`](diffhunk://#diff-40a529368454e04b4a9906e0d52865dafd67de9c9e639b53e1340c707a6bcf73L55-R56): Added a `header` parameter to the `write_output` function call in `cap_bindsites_pipeline` to provide more descriptive output.
* [`recsa/pipelines/bondset_enumeration.py`](diffhunk://#diff-704b7f75f91ab30ef6438b6e5eae64b9d529d80cb4bf4eb60816a026c67f4adeL147-R148): Modified `enum_bond_subsets_pipeline` to include a `header` parameter in the `write_output` function call.
* [`recsa/pipelines/bondset_to_assembly.py`](diffhunk://#diff-f70a73db8b73bee7401937572173537330be686abc41d7fb6a34bb7e9057ae5dL47-R48): Updated `bondsets_to_assemblies_pipeline` to pass a `header` parameter to the `write_output` function.
* [`recsa/pipelines/duplicate_exclusion.py`](diffhunk://#diff-ea0962ea6b85ff9785e7e32d71aaf3548f076dcf7f2189003bdd39ef5aa33793L47-R48): Enhanced `find_unique_assemblies_pipeline` to use a `header` parameter in the `write_output` function call.

Updates to `write_output` function:

* [`recsa/pipelines/lib/saving.py`](diffhunk://#diff-d5cd5db5ed3039d582e8d3d07f73b7dbd5b9bb7f91ee17f1b91d45810c5b88c1L12-R13): Added a `header` parameter to the `write_output` function, and adjusted the logging logic to include the header in the output message if provided. [[1]](diffhunk://#diff-d5cd5db5ed3039d582e8d3d07f73b7dbd5b9bb7f91ee17f1b91d45810c5b88c1L12-R13) [[2]](diffhunk://#diff-d5cd5db5ed3039d582e8d3d07f73b7dbd5b9bb7f91ee17f1b91d45810c5b88c1L25-R29)

Unit tests:

* [`recsa/pipelines/lib/tests/test_saving.py`](diffhunk://#diff-04c4ecdf04535cc6f25d02955725d3c83494b3aa4dfc29fc9150e182e05da97cR98-R108): Added a new test `test_header_with_verbose` to verify that the `header` parameter is correctly included in the output message when verbose mode is enabled.
* [`recsa/pipelines/tests/test_bondset_enumeration/test_enum_bond_subsets_pipline.py`](diffhunk://#diff-e55fd11ac3b1478f8b1ae1d8aefffba430a66dc1c5150bd4c0ba1ca6778dd98eL134-R134): Updated `test_verbose_true` to reflect the new output message format without the header.