### PR TITLE
Add concatenate_assemblies_pipeline function and related tests

### DIFF
--- a/recsa/pipelines/__init__.py
+++ b/recsa/pipelines/__init__.py
@@ -1,3 +1,4 @@
+from .assembly_list_concatenation import concatenate_assemblies_pipeline
 from .bindsite_capping import cap_bindsites_pipeline
 from .bondset_enumeration import enum_bond_subsets_pipeline
 from .bondset_to_assembly import bondsets_to_assemblies_pipeline

--- a/recsa/pipelines/assembly_list_concatenation.py
+++ b/recsa/pipelines/assembly_list_concatenation.py
@@ -1,0 +1,72 @@
+import os
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from recsa import Assembly
+from recsa.pipelines.lib import read_file, write_output
+
+
+def concatenate_assemblies_pipeline(
+        assemblies_path_list: Sequence[os.PathLike | str],
+        resulting_assems_path: os.PathLike | str,
+        *,
+        start: int = 0,
+        overwrite: bool = False,
+        verbose: bool = False,
+        ) -> None:
+    """Concatenate a list of assemblies into a single list.
+    
+    Concatenates a list of assemblies from different files into a single 
+    list. The IDs of the assemblies are reindexed starting from the given
+    start value.
+
+    Parameters
+    ----------
+    assemblies_path_list : Sequence[os.PathLike | str]
+        List of paths to the files containing the assemblies.
+        Each file should contain a dictionary with the assembly IDs as keys
+        and the Assembly objects as values.
+    resulting_assems_path : os.PathLike | str
+        Path to the file to save the concatenated list of assemblies.
+    start : int, optional
+        Starting index for the reindexing of the assemblies, by default 0.
+    overwrite : bool, optional
+        Whether to overwrite the file if it already exists, by default False.
+    verbose : bool, optional
+        Whether to print the process steps, by default False
+    
+    Notes
+    -----
+    The reindexing order is determined by the order of the input files and 
+    the order of the assemblies in each file, not by their alphabetical 
+    order.
+
+    Output file contains a dictionary with the reindexed IDs as keys and the
+    Assembly objects as values.
+    """
+    # Input
+    list_of_id_to_assembly: Sequence[Mapping[Any, Assembly]] = [
+        read_file(path, verbose=verbose)
+        for path in assemblies_path_list]
+    
+    # Main process
+    if verbose:
+        print('Concatenating assembly lists...')
+
+    assemblies: list[Assembly] = []
+    for id_to_assembly in list_of_id_to_assembly:
+        assemblies.extend(id_to_assembly.values())
+    
+    reindexed = {
+        new_id: assems for new_id, assems 
+        in enumerate(assemblies, start=start)
+    }
+    
+    if verbose:
+        print('Concatenation completed.')
+
+    # Save reindexed assemblies
+    write_output(
+        resulting_assems_path, reindexed,
+        overwrite=overwrite, verbose=verbose,
+        header='Concatenated list of assemblies')

--- a/recsa/pipelines/tests/test_assembly_list_concatenation.py
+++ b/recsa/pipelines/tests/test_assembly_list_concatenation.py
@@ -1,0 +1,197 @@
+import pytest
+import yaml
+
+from recsa import Assembly
+from recsa.pipelines import concatenate_assemblies_pipeline
+
+
+def test_basic(tmp_path):
+    assemblies_paths = [
+        tmp_path / 'assemblies-0.yaml',
+        tmp_path / 'assemblies-1.yaml']
+    
+    ASSEMBLIES = [
+        {0: Assembly({'L0': 'L'}), 1: Assembly({'M0': 'M'})},
+        {0: Assembly({'L1': 'L'}), 1: Assembly({'M1': 'M'})}]
+    
+    for path, assems in zip(assemblies_paths, ASSEMBLIES):
+        with open(path, 'w') as f:
+            yaml.dump(assems, f)
+
+    OUTPUT_PATH = tmp_path / 'concatenated.yaml'
+
+    concatenate_assemblies_pipeline(
+        assemblies_path_list=assemblies_paths,
+        resulting_assems_path=str(OUTPUT_PATH),
+        start=0, overwrite=True, verbose=False)
+
+    with open(OUTPUT_PATH, 'r') as f:
+        output_data = yaml.safe_load(f)
+
+    assert output_data == {
+        0: Assembly({'L0': 'L'}), 1: Assembly({'M0': 'M'}),
+        2: Assembly({'L1': 'L'}), 3: Assembly({'M1': 'M'})}
+
+
+def test_paths_order_preservation(tmp_path):
+    """Test that the order of the paths is preserved
+    regardless of their alphabetical order.
+    """
+    # The order of the paths is different from their alphabetical order.
+    assemblies_paths = [tmp_path / 'B.yaml', tmp_path / 'A.yaml']
+    
+    with open(tmp_path / 'B.yaml', 'w') as f:
+        yaml.dump({0: Assembly({'first': 'first'})}, f)
+    with open(tmp_path / 'A.yaml', 'w') as f:
+        yaml.dump({0: Assembly({'second': 'second'})}, f)
+    
+    output_path = tmp_path / 'concatenated.yaml'
+
+    concatenate_assemblies_pipeline(
+        assemblies_path_list=assemblies_paths,
+        resulting_assems_path=str(output_path),
+        start=0, overwrite=True, verbose=False)
+
+    with open(output_path, 'r') as f:
+        output_data = yaml.safe_load(f)
+
+    # The order of the paths should be preserved.
+    assert output_data == {
+        0: Assembly({'first': 'first'}), 1: Assembly({'second': 'second'})}
+
+
+def test_assembly_order_preservation(tmp_path):
+    """Test that the order of the assemblies in each file is preserved
+    regardless of the alphabetical order of the IDs.
+    """
+    assemblies_paths = [tmp_path / 'assemblies-0.yaml']
+    
+    # The order is different from their alphabetical order.
+    ASSEMBLIES = [{
+        'B': Assembly({'first': 'L'}), 
+        'A': Assembly({'second': 'L'}),
+        }]
+    
+    # Save the assemblies preserving the order
+    for path, assems in zip(assemblies_paths, ASSEMBLIES):
+        with open(path, 'w') as f:
+            yaml.dump(assems, f, sort_keys=False)  # keep the order
+
+    OUTPUT_PATH = tmp_path / 'concatenated.yaml'
+
+    concatenate_assemblies_pipeline(
+        assemblies_path_list=assemblies_paths,
+        resulting_assems_path=str(OUTPUT_PATH),
+        start=0, overwrite=True, verbose=False)
+
+    with open(OUTPUT_PATH, 'r') as f:
+        output_data = yaml.safe_load(f)
+
+    # The order of the assemblies should be preserved
+    assert output_data == {
+        0: Assembly({'first': 'L'}), 1: Assembly({'second': 'L'})}
+
+
+def test_start(tmp_path):
+    ASSEMBLIES = {
+        0: Assembly({'L0': 'L'}),
+        1: Assembly({'M0': 'M'}),
+    }
+
+    filepath = tmp_path / 'assemblies.yaml'
+    with open(filepath, 'w') as f:
+        yaml.dump(ASSEMBLIES, f)
+
+    OUTPUT_PATH = tmp_path / 'concatenated.yaml'
+
+    concatenate_assemblies_pipeline(
+        assemblies_path_list=[filepath],
+        resulting_assems_path=str(OUTPUT_PATH),
+        start=10, overwrite=True, verbose=False)
+
+    with open(OUTPUT_PATH, 'r') as f:
+        output_data = yaml.safe_load(f)
+
+    assert output_data == {
+        10: Assembly({'L0': 'L'}),
+        11: Assembly({'M0': 'M'})}
+
+
+def test_overwrite_true(tmp_path):
+    ASSEMBLIES = {0: Assembly({'L0': 'L'})}
+    filepath = tmp_path / 'assemblies.yaml'
+    with open(filepath, 'w') as f:
+        yaml.dump(ASSEMBLIES, f)
+    
+    OUTPUT_PATH = tmp_path / 'concatenated.yaml'
+    with open(OUTPUT_PATH, 'w') as f:
+        yaml.dump('previous data', f)
+
+    concatenate_assemblies_pipeline(
+        assemblies_path_list=[filepath],
+        resulting_assems_path=str(OUTPUT_PATH),
+        start=0, overwrite=True, verbose=False)
+    
+    with open(OUTPUT_PATH, 'r') as f:
+        output_data = yaml.safe_load(f)
+
+    assert output_data == {0: Assembly({'L0': 'L'})}
+
+
+def test_overwrite_false(tmp_path):
+    ASSEMBLIES = {0: Assembly({'L0': 'L'})}
+    filepath = tmp_path / 'assemblies.yaml'
+    with open(filepath, 'w') as f:
+        yaml.dump(ASSEMBLIES, f)
+    
+    OUTPUT_PATH = tmp_path / 'concatenated.yaml'
+    with open(OUTPUT_PATH, 'w') as f:
+        yaml.dump('previous data', f)
+
+    with pytest.raises(FileExistsError):
+         concatenate_assemblies_pipeline(
+            assemblies_path_list=[filepath],
+            resulting_assems_path=str(OUTPUT_PATH),
+            start=0, overwrite=False, verbose=False)
+
+
+def test_verbose_true(tmp_path, capsys):
+    ASSEMBLIES = {0: Assembly({'L0': 'L'})}
+    filepath = tmp_path / 'assemblies.yaml'
+    with open(filepath, 'w') as f:
+        yaml.dump(ASSEMBLIES, f)
+    
+    OUTPUT_PATH = tmp_path / 'concatenated.yaml'
+
+    concatenate_assemblies_pipeline(
+        assemblies_path_list=[filepath],
+        resulting_assems_path=str(OUTPUT_PATH),
+        start=0, overwrite=True, verbose=True)
+
+    captured = capsys.readouterr()
+    assert f'Finished reading from "{filepath}"' in captured.out
+    assert 'Concatenating assembly lists...' in captured.out
+    assert 'Concatenation completed.' in captured.out
+    assert f'Successfully saved to "{OUTPUT_PATH}".' in captured.out
+
+
+def test_verbose_false(tmp_path, capsys):
+    ASSEMBLIES = {0: Assembly({'L0': 'L'})}
+    filepath = tmp_path / 'assemblies.yaml'
+    with open(filepath, 'w') as f:
+        yaml.dump(ASSEMBLIES, f)
+    
+    OUTPUT_PATH = tmp_path / 'concatenated.yaml'
+
+    concatenate_assemblies_pipeline(
+        assemblies_path_list=[filepath],
+        resulting_assems_path=str(OUTPUT_PATH),
+        start=0, overwrite=True, verbose=False)
+
+    captured = capsys.readouterr()
+    assert captured.out == ''
+    assert captured.err == ''
+
+
+if __name__ == '__main__':
+    pytest.main(['-vv', __file__])


### PR DESCRIPTION
This pull request introduces a new pipeline for concatenating assembly lists, along with corresponding tests to ensure its functionality. The most important changes include the addition of the new pipeline function, its integration into the existing pipeline module, and the creation of comprehensive tests.

### New Pipeline Function

* [`recsa/pipelines/assembly_list_concatenation.py`](diffhunk://#diff-3ce472711d51fcb93bbf151f5a7b468ab652b416b114cee7159feaba6eb39037R1-R72): Added the `concatenate_assemblies_pipeline` function to concatenate multiple assembly lists into a single list, with options for reindexing, overwriting existing files, and verbose output.

### Integration into Existing Module

* [`recsa/pipelines/__init__.py`](diffhunk://#diff-5face669fd17f99ef76de27fa11d6bfa3f654ab42e230ba63754047d4cb81fc6R1): Imported the newly created `concatenate_assemblies_pipeline` function to make it available as part of the `recsa.pipelines` module.

### Tests for New Pipeline

* [`recsa/pipelines/tests/test_assembly_list_concatenation.py`](diffhunk://#diff-921030a9195f1926b46315229ca543e567f417dc5249397adb009ef2aa6ffc45R1-R197): Added a suite of tests to verify the functionality of the `concatenate_assemblies_pipeline` function, including tests for basic concatenation, order preservation, reindexing, overwriting behavior, and verbose output.