### PR TITLE
Update bond subset output format to use a dictionary

### DIFF
--- a/recsa/cli/tests/test_bondset_enumeration.py
+++ b/recsa/cli/tests/test_bondset_enumeration.py
@@ -23,7 +23,9 @@ def test_cli_command_a(tmp_path):
         }
     }
     
-    EXPECTED = [[1], [2], [1, 2], [2, 3], [1, 2, 3], [1, 2, 3, 4]]
+    EXPECTED = {
+        0: [1], 1: [2], 2: [1, 2], 3: [2, 3], 4: [1, 2, 3], 5: [1, 2, 3, 4]
+    }
 
 
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:

--- a/recsa/cli/tests/test_main.py
+++ b/recsa/cli/tests/test_main.py
@@ -23,7 +23,9 @@ def test_enum_bond_subsets(tmp_path):
         }
     }
 
-    EXPECTED = [[1], [2], [1, 2], [2, 3], [1, 2, 3], [1, 2, 3, 4]]
+    EXPECTED = {
+        0: [1], 1: [2], 2: [1, 2], 3: [2, 3], 4: [1, 2, 3], 5: [1, 2, 3, 4]
+    }
 
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
         input_path = os.path.join(td, 'input.yaml')

--- a/recsa/pipelines/bondset_enumeration.py
+++ b/recsa/pipelines/bondset_enumeration.py
@@ -108,19 +108,20 @@ def enum_bond_subsets_pipeline(
             C2: [[1, 4], [2, 3]]
 
     Style of Output File:
-        The output file will be a list of lists of bond IDs in YAML format.
-        Each list represents a connected subset of bonds. The subsets are
-        sorted in a consistent order based on the length of each subset
-        and the elements within each subset.
+        The output file will be a dictionary with integer keys 
+        starting from 0. Each key maps to a list of bond IDs representing 
+        a connected subset of bonds. The subsets are sorted in a consistent 
+        order based on the length of each subset and the elements within 
+        each subset.
     
     Example of Output File::
     
-        - [1]
-        - [2]
-        - [1, 2]
-        - [2, 3]
-        - [1, 2, 3]
-        - [1, 2, 3, 4]
+        0: [1]
+        1: [2]
+        2: [1, 2]
+        3: [2, 3]
+        4: [1, 2, 3]
+        5: [1, 2, 3, 4]
     """
     # Input
     input_data = read_file(input_path, verbose=verbose)
@@ -143,8 +144,13 @@ def enum_bond_subsets_pipeline(
     
     # Output
     formatted_result = sort_bond_subsets(result)
+
+    id_to_bondset = {
+        id_: bondset for id_, bondset in enumerate(formatted_result)
+        }
+    
     write_output(
-        output_path, formatted_result, overwrite=overwrite, verbose=verbose,
+        output_path, id_to_bondset, overwrite=overwrite, verbose=verbose,
         header='Enumerated bond subsets')
 
 

--- a/recsa/pipelines/tests/test_bondset_enumeration/test_enum_bond_subsets_pipline.py
+++ b/recsa/pipelines/tests/test_bondset_enumeration/test_enum_bond_subsets_pipline.py
@@ -18,12 +18,12 @@ def test_without_sym_ops(tmp_path):
             4: {3},
         }
     }
-    EXPECTED = [
-        [1], [2], [3], [4],
-        [1, 2], [2, 3], [3, 4],
-        [1, 2, 3], [2, 3, 4],
-        [1, 2, 3, 4]
-    ]
+    EXPECTED = {
+        0: [1], 1: [2], 2: [3], 3: [4],
+        4: [1, 2], 5: [2, 3], 6: [3, 4],
+        7: [1, 2, 3], 8: [2, 3, 4],
+        9: [1, 2, 3, 4]
+    }
     input_path = tmp_path / "input.yaml"
     with open(input_path, 'w') as f:
         yaml.safe_dump(INPUT_DATA, f)
@@ -52,9 +52,9 @@ def test_with_sym_ops(tmp_path):
             'C2': {1: 4, 2: 3, 3: 2, 4: 1}
         }
     }
-    EXPECTED = [
-        [1], [2], [1, 2], [2, 3], [1, 2, 3], [1, 2, 3, 4]
-    ]
+    EXPECTED = {
+        0: [1], 1: [2], 2: [1, 2], 3: [2, 3], 4: [1, 2, 3], 5: [1, 2, 3, 4]
+    }
     input_path = tmp_path / "input.yaml"
     with open(input_path, 'w') as f:
         yaml.safe_dump(INPUT_DATA, f)


### PR DESCRIPTION
This pull request updates the format of the expected output for bond subset enumeration from a list of lists to a dictionary with integer keys. The changes affect both the implementation and the corresponding tests.

Changes to bond subset enumeration:

* [`recsa/pipelines/bondset_enumeration.py`](diffhunk://#diff-704b7f75f91ab30ef6438b6e5eae64b9d529d80cb4bf4eb60816a026c67f4adeL111-R124): Updated the output format description and modified the function to produce a dictionary with integer keys mapping to lists of bond IDs. [[1]](diffhunk://#diff-704b7f75f91ab30ef6438b6e5eae64b9d529d80cb4bf4eb60816a026c67f4adeL111-R124) [[2]](diffhunk://#diff-704b7f75f91ab30ef6438b6e5eae64b9d529d80cb4bf4eb60816a026c67f4adeR147-R153)

Updates to test cases:

* [`recsa/cli/tests/test_bondset_enumeration.py`](diffhunk://#diff-23c435ebb228025698410b8e7adbbd968a3e30a472f363458c06414bce43d7a1L26-R28): Changed the `EXPECTED` variable to use a dictionary format in `test_cli_command_a`.
* [`recsa/cli/tests/test_main.py`](diffhunk://#diff-5959c8dd8d812378f45cdde07b3305907e395a2c32aeed87e1a8466a29f47608L26-R28): Changed the `EXPECTED` variable to use a dictionary format in `test_enum_bond_subsets`.
* [`recsa/pipelines/tests/test_bondset_enumeration/test_enum_bond_subsets_pipline.py`](diffhunk://#diff-e55fd11ac3b1478f8b1ae1d8aefffba430a66dc1c5150bd4c0ba1ca6778dd98eL21-R26): Changed the `EXPECTED` variable to use a dictionary format in `test_without_sym_ops` and `test_with_sym_ops`. [[1]](diffhunk://#diff-e55fd11ac3b1478f8b1ae1d8aefffba430a66dc1c5150bd4c0ba1ca6778dd98eL21-R26) [[2]](diffhunk://#diff-e55fd11ac3b1478f8b1ae1d8aefffba430a66dc1c5150bd4c0ba1ca6778dd98eL55-R57)