### PR TITLE
Update/input file structure

### DIFF
--- a/recsa/pipelines/bindsite_capping.py
+++ b/recsa/pipelines/bindsite_capping.py
@@ -29,7 +29,7 @@ def cap_bindsites_pipeline(
     id_to_assembly: Mapping[Hashable, Assembly] = read_file(
         assemblies_path, verbose=verbose)
     components: Mapping[str, Component] = read_file(
-        components_path, verbose=verbose)
+        components_path, verbose=verbose)['component_kinds']
     config: CappingConfig = read_file(
         config_path, verbose=verbose)['capping_config']
     

--- a/recsa/pipelines/duplicate_exclusion.py
+++ b/recsa/pipelines/duplicate_exclusion.py
@@ -25,7 +25,7 @@ def find_unique_assemblies_pipeline(
     id_to_assembly: Mapping[Hashable, Assembly] = read_file(
         assemblies_path, verbose=verbose)
     components: Mapping[str, Component] = read_file(
-        components_path, verbose=verbose)
+        components_path, verbose=verbose)['component_kinds']
     
     # Main process
     if verbose:

--- a/recsa/pipelines/tests/test_bindsite_capping.py
+++ b/recsa/pipelines/tests/test_bindsite_capping.py
@@ -18,11 +18,11 @@ def assemblies_data():
 
 @pytest.fixture
 def components_data():
-    return {
+    return {'component_kinds': {
         'L': Component(['a', 'b']),
         'M': Component(['a', 'b']),
         'X': Component(['a']),
-    }
+    }}
 
 
 def test_add_X_on_M(
@@ -32,8 +32,7 @@ def test_add_X_on_M(
     config_path = tmp_path / 'config.yaml'
     output_path = tmp_path / 'output.yaml'
 
-    CONFIG_DATA = {
-        'capping_config': {
+    CONFIG_DATA = {'capping_config': {
         'target_component_kind': 'M',
         'capping_component_kind': 'X',
         'capping_bindsite': 'a'
@@ -76,7 +75,7 @@ def test_add_X_on_M(
     for assembly_id, expected_assembly in EXPECTED_CAPPED_ASSEMBLIES.items():
         assert is_isomorphic(
             output_data[assembly_id], expected_assembly,
-            components_data)
+            components_data['component_kinds'])
 
 
 def test_add_L_on_M(
@@ -130,7 +129,7 @@ def test_add_L_on_M(
     for assembly_id, expected_assembly in EXPECTED_CAPPED_ASSEMBLIES.items():
         assert is_isomorphic(
             output_data[assembly_id], expected_assembly,
-            components_data)
+            components_data['component_kinds'])
         
 
 if __name__ == '__main__':

--- a/recsa/pipelines/tests/test_duplicate_exclusion.py
+++ b/recsa/pipelines/tests/test_duplicate_exclusion.py
@@ -30,9 +30,10 @@ def assemblies_data():
 @pytest.fixture
 def components_data():
     return {
-        'L': Component(['a', 'b']),
-        'M': Component(['a', 'b'])
-    }
+        'component_kinds': {
+            'L': Component(['a', 'b']),
+            'M': Component(['a', 'b'])
+            }}
 
 @pytest.fixture
 def expected_unique_assemblies(assemblies_data):


### PR DESCRIPTION
This pull request includes changes to improve the handling of component kinds in the `recsa/pipelines` module and its associated tests. The changes ensure that the `components` dictionary is accessed through the `component_kinds` key, which standardizes the data structure across the pipeline and test files.

### Changes to pipeline functions:

* [`recsa/pipelines/bindsite_capping.py`](diffhunk://#diff-40a529368454e04b4a9906e0d52865dafd67de9c9e639b53e1340c707a6bcf73L32-R32): Modified the `components` dictionary to be accessed through the `component_kinds` key in the `cap_bindsites_pipeline` function.
* [`recsa/pipelines/duplicate_exclusion.py`](diffhunk://#diff-ea0962ea6b85ff9785e7e32d71aaf3548f076dcf7f2189003bdd39ef5aa33793L28-R28): Modified the `components` dictionary to be accessed through the `component_kinds` key in the `find_unique_assemblies_pipeline` function.

### Changes to test functions:

* [`recsa/pipelines/tests/test_bindsite_capping.py`](diffhunk://#diff-bee7ffcc646b71f09c8434d404a57f7b9048ae54e4f5486b326000fe431ee694L21-R25): Updated the `components_data` fixture to include the `component_kinds` key. Modified the `test_add_X_on_M` and `test_add_L_on_M` functions to access components through the `component_kinds` key. [[1]](diffhunk://#diff-bee7ffcc646b71f09c8434d404a57f7b9048ae54e4f5486b326000fe431ee694L21-R25) [[2]](diffhunk://#diff-bee7ffcc646b71f09c8434d404a57f7b9048ae54e4f5486b326000fe431ee694L35-R35) [[3]](diffhunk://#diff-bee7ffcc646b71f09c8434d404a57f7b9048ae54e4f5486b326000fe431ee694L79-R78) [[4]](diffhunk://#diff-bee7ffcc646b71f09c8434d404a57f7b9048ae54e4f5486b326000fe431ee694L133-R132)
* [`recsa/pipelines/tests/test_duplicate_exclusion.py`](diffhunk://#diff-68cbfcc9a47959d830f33188bbba9c8368493965b35c8532348ee84ff0a2477aR33-R36): Updated the `components_data` fixture to include the `component_kinds` key.