### PR TITLE
Rename 'capping_bindsite' to 'capping_binding_site' for consistency

### DIFF
--- a/recsa/pipelines/bindsite_capping.py
+++ b/recsa/pipelines/bindsite_capping.py
@@ -9,7 +9,7 @@ from recsa.pipelines.lib import read_file, write_output
 class CappingConfig(TypedDict):
     target_component_kind: str
     capping_component_kind: str
-    capping_bindsite: str
+    capping_binding_site: str
 
 
 # ============================================================
@@ -43,7 +43,7 @@ def cap_bindsites_pipeline(
             assembly, components, 
             config['target_component_kind'],
             config['capping_component_kind'],
-            config['capping_bindsite'],
+            config['capping_binding_site'],
             copy=True)
         
     if verbose:

--- a/recsa/pipelines/tests/test_bindsite_capping.py
+++ b/recsa/pipelines/tests/test_bindsite_capping.py
@@ -35,7 +35,7 @@ def test_add_X_on_M(
     CONFIG_DATA = {'capping_config': {
         'target_component_kind': 'M',
         'capping_component_kind': 'X',
-        'capping_bindsite': 'a'
+        'capping_binding_site': 'a'
     }}
 
     EXPECTED_CAPPED_ASSEMBLIES = {
@@ -89,7 +89,7 @@ def test_add_L_on_M(
         'capping_config': {
         'target_component_kind': 'M',
         'capping_component_kind': 'L',
-        'capping_bindsite': 'a'
+        'capping_binding_site': 'a'
     }}
 
     EXPECTED_CAPPED_ASSEMBLIES = {


### PR DESCRIPTION
This pull request includes changes to correct a typo in the `recsa/pipelines/bindsite_capping.py` file and its corresponding test file. The typo correction involves changing the key `capping_bindsite` to `capping_binding_site`.

Key changes include:

* Corrected the typo in the `CappingConfig` class definition by changing `capping_bindsite` to `capping_binding_site`.
* Updated the `cap_bindsites_pipeline` function to use `capping_binding_site` instead of `capping_bindsite`.
* Modified the `test_add_X_on_M` and `test_add_L_on_M` functions in the test file to reflect the corrected key `capping_binding_site`. [[1]](diffhunk://#diff-bee7ffcc646b71f09c8434d404a57f7b9048ae54e4f5486b326000fe431ee694L38-R38) [[2]](diffhunk://#diff-bee7ffcc646b71f09c8434d404a57f7b9048ae54e4f5486b326000fe431ee694L92-R92)