### PR TITLE
Add assembly enumeration pipeline and corresponding tests

### DIFF
--- a/recsa/pipelines/__init__.py
+++ b/recsa/pipelines/__init__.py
@@ -1,3 +1,4 @@
+from .assembly_enumeration import enumerate_assemblies_pipeline
 from .assembly_list_concatenation import concatenate_assemblies_pipeline
 from .bindsite_capping import cap_bindsites_pipeline
 from .bondset_enumeration import enum_bond_subsets_pipeline

--- a/recsa/pipelines/assembly_enumeration.py
+++ b/recsa/pipelines/assembly_enumeration.py
@@ -1,0 +1,52 @@
+import os
+import tempfile
+from collections.abc import Hashable
+from pathlib import Path
+from typing import TypeVar
+
+from .assembly_list_concatenation import concatenate_assemblies_pipeline
+from .bindsite_capping import cap_bindsites_pipeline
+from .bondset_enumeration import enum_bond_subsets_pipeline
+from .bondset_to_assembly import bondsets_to_assemblies_pipeline
+from .duplicate_exclusion import find_unique_assemblies_pipeline
+
+
+def enumerate_assemblies_pipeline(
+        input_path: os.PathLike | str,
+        output_path: os.PathLike | str,
+        *,
+        overwrite: bool = False,
+        verbose: bool = False,
+        wip_dir: os.PathLike | str | None = None
+        ) -> None:
+    with tempfile.TemporaryDirectory(dir=wip_dir) as temp_dir:
+        if wip_dir is None:
+            wip_dir = temp_dir
+        wip_dir = Path(wip_dir)
+
+        wip1_bondsets_path = wip_dir / 'wip1_bondsets.yaml'
+        wip2_assemblies_path = wip_dir / 'wip2_assemblies.yaml'
+        wip3_unique_assemblies_path = wip_dir / 'wip3_unique_assemblies.yaml'
+        wip4_capped_assemblies_path = wip_dir / 'wip4_capped_assemblies.yaml'
+
+        if verbose:
+            print('Enumerating assemblies...')
+            
+        enum_bond_subsets_pipeline(
+            input_path, wip1_bondsets_path, overwrite=overwrite)
+        bondsets_to_assemblies_pipeline(
+            wip1_bondsets_path, input_path, wip2_assemblies_path,
+            overwrite=overwrite)
+        find_unique_assemblies_pipeline(
+            wip2_assemblies_path, input_path, wip3_unique_assemblies_path,
+            overwrite=overwrite)
+        cap_bindsites_pipeline(
+            wip3_unique_assemblies_path, input_path, input_path, wip4_capped_assemblies_path,
+            overwrite=overwrite)
+        concatenate_assemblies_pipeline(
+            [wip4_capped_assemblies_path], output_path, overwrite=overwrite)
+        
+
+        if verbose:
+            print('Assembly enumeration completed.')
+            print(f'Successfully saved to {output_path}.')

--- a/recsa/pipelines/tests/test_assembly_enumeration.py
+++ b/recsa/pipelines/tests/test_assembly_enumeration.py
@@ -1,0 +1,94 @@
+import pytest
+import yaml
+
+from recsa import Assembly, Component, is_isomorphic
+from recsa.pipelines import enumerate_assemblies_pipeline
+
+
+def test_basic(tmp_path):
+    # M2L3 linear: L1-M1-L2-M2-L3
+    # bonds: 1, 2, 3, 4 from left to right
+    INPUT_DATA = {
+        'bonds': [1, 2, 3, 4],
+        'bond_adjacency': {
+            1: {2},
+            2: {1, 3},
+            3: {2, 4},
+            4: {3},
+        },
+        'sym_ops_by_bond_maps': {
+            'C2': {1: 4, 2: 3, 3: 2, 4: 1}
+        },
+        'sym_ops_by_bond_perms': {
+            'C2': [[1, 4], [2, 3]]
+        },
+        'component_kinds': {
+            'L': Component(['a', 'b']),
+            'M': Component(['a', 'b']),
+            'X': Component(['a']),
+        },
+        'components_and_their_kinds': {
+            'M1': 'M',
+            'M2': 'M',
+            'L1': 'L',
+            'L2': 'L',
+            'L3': 'L'
+        },
+        'bonds_and_their_binding_sites': {
+            1: ['L1.b', 'M1.a'],
+            2: ['M1.b', 'L2.a'],
+            3: ['L2.b', 'M2.a'],
+            4: ['M2.b', 'L3.a']
+        },
+        'capping_config': {
+            'target_component_kind': 'M',
+            'capping_component_kind': 'X',
+            'capping_binding_site': 'a'
+        }
+    }
+
+    input_path = tmp_path / "input.yaml"
+    with open(input_path, 'w') as f:
+        yaml.dump(INPUT_DATA, f)
+    
+    output_path = tmp_path / "output.yaml"
+    enumerate_assemblies_pipeline(input_path, output_path)
+
+    EXPECTED = {
+        # L1--M1--X1
+        0: Assembly(
+            {'L1': 'L', 'M1': 'M', 'X1': 'X'}, 
+            [('L1.b', 'M1.a'), ('M1.b', 'X1.a')]),
+        # L1--M1--L2
+        1: Assembly(
+            {'L1': 'L', 'M1': 'M', 'L2': 'L'}, 
+            [('L1.b', 'M1.a'), ('M1.b', 'L2.a')]),
+        # X1--M1--L2--M2--X2
+        2: Assembly(
+            {'X1': 'X', 'M1': 'M', 'L2': 'L', 'M2': 'M', 'X2': 'X'}, 
+            [('X1.a', 'M1.a'), ('M1.b', 'L2.a'), ('L2.b', 'M2.a'),
+             ('M2.b', 'X2.a')]),
+        # L1--M1--L2--M2--X1
+        3: Assembly(
+            {'L1': 'L', 'M1': 'M', 'L2': 'L', 'M2': 'M', 'X1': 'X'}, 
+            [('L1.b', 'M1.a'), ('M1.b', 'L2.a'), ('L2.b', 'M2.a'),
+             ('M2.b', 'X1.a')]),
+        # L1--M1--L2--M2--L3
+        4: Assembly(
+            {'L1': 'L', 'M1': 'M', 'L2': 'L', 'M2': 'M', 'L3': 'L'}, 
+            [('L1.b', 'M1.a'), ('M1.b', 'L2.a'), ('L2.b', 'M2.a'), 
+             ('M2.b', 'L3.a')]),
+        }
+    
+    with open(output_path, 'r') as f:
+        actual_output = yaml.safe_load(f)
+
+    conponent_kinds = INPUT_DATA['component_kinds']
+    for index, assembly in EXPECTED.items():
+        assert is_isomorphic(
+            assembly, actual_output[index], 
+            INPUT_DATA['component_kinds'])  # type: ignore
+
+
+if __name__ == "__main__":
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces a new pipeline for enumerating assemblies in the `recsa` package, along with a corresponding test to validate its functionality. The key changes are the addition of the `enumerate_assemblies_pipeline` function and the creation of a test case for this function.

New pipeline addition:

* [`recsa/pipelines/__init__.py`](diffhunk://#diff-5face669fd17f99ef76de27fa11d6bfa3f654ab42e230ba63754047d4cb81fc6R1): Added import for the new `enumerate_assemblies_pipeline` function.
* [`recsa/pipelines/assembly_enumeration.py`](diffhunk://#diff-923101afe72b946d68ef3538dbfb76a0afb2268f1732227799fc76beac9aa487R1-R52): Implemented the `enumerate_assemblies_pipeline` function, which orchestrates the enumeration of assemblies through several pipeline stages.

Testing enhancements:

* [`recsa/pipelines/tests/test_assembly_enumeration.py`](diffhunk://#diff-1de7a9a9eec8d4b571c257d2196d7f23700faf9f9c43a5b9ea07a6cecf681885R1-R94): Added a new test case to validate the `enumerate_assemblies_pipeline` function, ensuring it produces the expected output given a specific input.