### PR TITLE
Remove wip_dir parameter from TemporaryDirectory

### DIFF
--- a/recsa/pipelines/assembly_enumeration.py
+++ b/recsa/pipelines/assembly_enumeration.py
@@ -19,7 +19,7 @@ def enumerate_assemblies_pipeline(
         verbose: bool = False,
         wip_dir: os.PathLike | str | None = None
         ) -> None:
-    with tempfile.TemporaryDirectory(dir=wip_dir) as temp_dir:
+    with tempfile.TemporaryDirectory() as temp_dir:
         if wip_dir is None:
             wip_dir = temp_dir
         wip_dir = Path(wip_dir)


### PR DESCRIPTION
This pull request includes a minor change to the `enumerate_assemblies_pipeline` function in the `recsa/pipelines/assembly_enumeration.py` file. The change simplifies the creation of a temporary directory by removing the `dir` parameter from the `tempfile.TemporaryDirectory` call.

* [`recsa/pipelines/assembly_enumeration.py`](diffhunk://#diff-923101afe72b946d68ef3538dbfb76a0afb2268f1732227799fc76beac9aa487L22-R22): Removed the `dir` parameter from the `tempfile.TemporaryDirectory` call in the `enumerate_assemblies_pipeline` function.