### PR TITLE
Add enumerate assemblies command and associated tests

### DIFF
--- a/recsa/cli/commands.py
+++ b/recsa/cli/commands.py
@@ -1,7 +1,41 @@
 import click
 
 from recsa.pipelines import (bondsets_to_assemblies_pipeline,
-                             enum_bond_subsets_pipeline)
+                             enum_bond_subsets_pipeline,
+                             enumerate_assemblies_pipeline)
+
+
+@click.command('enumerate-assemblies')
+@click.argument('input', type=click.Path(exists=True))
+@click.argument('output', type=click.Path())
+@click.option(
+    '--wip-dir', '-w', type=click.Path(), 
+    help='Directory to store intermediate files.')
+@click.option(
+    '--overwrite', '-o',
+    is_flag=True, help='Overwrite output file if it exists.')
+@click.option(
+    '--verbose', '-v',
+    is_flag=True, help='Print verbose output.')
+def run_enum_assemblies_pipeline(input, output, wip_dir, overwrite, verbose):
+    """Enumerates assemblies.
+    
+    \b
+    Parameters
+    ----------
+    - INPUT: Path to input file.
+    - OUTPUT: Path to output file.
+
+    \b
+    Options
+    -------
+    --wip-dir, -w: Directory to store intermediate files.
+    --overwrite, -o: Overwrite output file if it exists.
+    --verbose, -v: Print verbose output
+    """
+    enumerate_assemblies_pipeline(
+        input, output,
+        wip_dir=wip_dir, overwrite=overwrite, verbose=verbose)
 
 
 @click.command('enumerate-bond-subsets')

--- a/recsa/cli/main.py
+++ b/recsa/cli/main.py
@@ -1,6 +1,7 @@
 import click
 
 from recsa.cli.commands import (run_bondsets_to_assemblies_pipeline,
+                                run_enum_assemblies_pipeline,
                                 run_enum_bond_subsets_pipeline)
 
 
@@ -11,6 +12,7 @@ def main():
 
 main.add_command(run_enum_bond_subsets_pipeline)
 main.add_command(run_bondsets_to_assemblies_pipeline)
+main.add_command(run_enum_assemblies_pipeline)
 
 if __name__ == '__main__':
     main()

--- a/recsa/cli/tests/test_assembly_enumeration.py
+++ b/recsa/cli/tests/test_assembly_enumeration.py
@@ -1,0 +1,111 @@
+import os
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from recsa import Assembly, Component, is_isomorphic
+from recsa.cli.commands import run_enum_assemblies_pipeline
+
+
+@pytest.fixture
+def input_data():
+    return {
+        'bonds': [1, 2, 3, 4],
+        'bond_adjacency': {
+            1: [2],
+            2: [1, 3],
+            3: [2, 4],
+            4: [3],
+        },
+        'sym_ops_by_bond_maps': {
+            'C2': {1: 4, 2: 3, 3: 2, 4: 1}
+        },
+        'sym_ops_by_bond_perms': {
+            'C2': [[1, 4], [2, 3]]
+        },
+        'component_kinds': {
+            'L': Component(['a', 'b']),
+            'M': Component(['a', 'b']),
+            'X': Component(['a']),
+        },
+        'components_and_their_kinds': {
+            'M1': 'M',
+            'M2': 'M',
+            'L1': 'L',
+            'L2': 'L',
+            'L3': 'L'
+        },
+        'bonds_and_their_binding_sites': {
+            1: ['L1.b', 'M1.a'],
+            2: ['M1.b', 'L2.a'],
+            3: ['L2.b', 'M2.a'],
+            4: ['M2.b', 'L3.a']
+        },
+        'capping_config': {
+            'target_component_kind': 'M',
+            'capping_component_kind': 'X',
+            'capping_binding_site': 'a'
+        }
+    }
+
+
+@pytest.fixture
+def expected_output_data():
+    return {
+        # L1--M1--X1
+        0: Assembly(
+            {'L1': 'L', 'M1': 'M', 'X1': 'X'}, 
+            [('L1.b', 'M1.a'), ('M1.b', 'X1.a')]),
+        # L1--M1--L2
+        1: Assembly(
+            {'L1': 'L', 'M1': 'M', 'L2': 'L'}, 
+            [('L1.b', 'M1.a'), ('M1.b', 'L2.a')]),
+        # X1--M1--L2--M2--X2
+        2: Assembly(
+            {'X1': 'X', 'M1': 'M', 'L2': 'L', 'M2': 'M', 'X2': 'X'}, 
+            [('X1.a', 'M1.a'), ('M1.b', 'L2.a'), ('L2.b', 'M2.a'),
+             ('M2.b', 'X2.a')]),
+        # L1--M1--L2--M2--X1
+        3: Assembly(
+            {'L1': 'L', 'M1': 'M', 'L2': 'L', 'M2': 'M', 'X1': 'X'}, 
+            [('L1.b', 'M1.a'), ('M1.b', 'L2.a'), ('L2.b', 'M2.a'),
+             ('M2.b', 'X1.a')]),
+        # L1--M1--L2--M2--L3
+        4: Assembly(
+            {'L1': 'L', 'M1': 'M', 'L2': 'L', 'M2': 'M', 'L3': 'L'}, 
+            [('L1.b', 'M1.a'), ('M1.b', 'L2.a'), ('L2.b', 'M2.a'), 
+             ('M2.b', 'L3.a')]),
+        }
+
+
+def test_run_enum_assemblies_pipeline(
+        tmp_path, input_data, expected_output_data):
+    runner = CliRunner()
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        input_path = os.path.join(td, 'input.yaml')
+        output_path = os.path.join(td, 'output.yaml')
+        wip_dir = os.path.join(td, 'tmp')
+
+        with open(input_path, 'w') as f:
+            yaml.dump(input_data, f)
+
+        result = runner.invoke(
+            run_enum_assemblies_pipeline, [
+                str(input_path), str(output_path), 
+                '--wip-dir', str(wip_dir), 
+                '--overwrite', '--verbose'])
+
+        assert result.exit_code == 0
+
+        with open(output_path, 'r') as f:
+            output_data = yaml.safe_load(f)
+
+        for key, assembly in expected_output_data.items():
+            assert is_isomorphic(
+                output_data[key], assembly, input_data['component_kinds'])
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])

--- a/recsa/cli/tests/test_main.py
+++ b/recsa/cli/tests/test_main.py
@@ -4,8 +4,105 @@ import pytest
 import yaml
 from click.testing import CliRunner
 
-from recsa import Assembly
+from recsa import Assembly, Component, is_isomorphic
 from recsa.cli.main import main
+
+
+def test_enumerate_assemblies(tmp_path):
+    runner = CliRunner()
+
+    INPUT_DATA = {
+        'bonds': [1, 2, 3, 4],
+        'bond_adjacency': {
+            1: [2],
+            2: [1, 3],
+            3: [2, 4],
+            4: [3],
+        },
+        'sym_ops_by_bond_maps': {
+            'C2': {1: 4, 2: 3, 3: 2, 4: 1}
+        },
+        'sym_ops_by_bond_perms': {
+            'C2': [[1, 4], [2, 3]]
+        },
+        'component_kinds': {
+            'L': Component(['a', 'b']),
+            'M': Component(['a', 'b']),
+            'X': Component(['a']),
+        },
+        'components_and_their_kinds': {
+            'M1': 'M',
+            'M2': 'M',
+            'L1': 'L',
+            'L2': 'L',
+            'L3': 'L'
+        },
+        'bonds_and_their_binding_sites': {
+            1: ['L1.b', 'M1.a'],
+            2: ['M1.b', 'L2.a'],
+            3: ['L2.b', 'M2.a'],
+            4: ['M2.b', 'L3.a']
+        },
+        'capping_config': {
+            'target_component_kind': 'M',
+            'capping_component_kind': 'X',
+            'capping_binding_site': 'a'
+        }
+    }
+
+    EXPECTED = {
+        # L1--M1--X1
+        0: Assembly(
+            {'L1': 'L', 'M1': 'M', 'X1': 'X'}, 
+            [('L1.b', 'M1.a'), ('M1.b', 'X1.a')]),
+        # L1--M1--L2
+        1: Assembly(
+            {'L1': 'L', 'M1': 'M', 'L2': 'L'}, 
+            [('L1.b', 'M1.a'), ('M1.b', 'L2.a')]),
+        # X1--M1--L2--M2--X2
+        2: Assembly(
+            {'X1': 'X', 'M1': 'M', 'L2': 'L', 'M2': 'M', 'X2': 'X'}, 
+            [('X1.a', 'M1.a'), ('M1.b', 'L2.a'), ('L2.b', 'M2.a'),
+             ('M2.b', 'X2.a')]),
+        # L1--M1--L2--M2--X1
+        3: Assembly(
+            {'L1': 'L', 'M1': 'M', 'L2': 'L', 'M2': 'M', 'X1': 'X'}, 
+            [('L1.b', 'M1.a'), ('M1.b', 'L2.a'), ('L2.b', 'M2.a'),
+             ('M2.b', 'X1.a')]),
+        # L1--M1--L2--M2--L3
+        4: Assembly(
+            {'L1': 'L', 'M1': 'M', 'L2': 'L', 'M2': 'M', 'L3': 'L'}, 
+            [('L1.b', 'M1.a'), ('M1.b', 'L2.a'), ('L2.b', 'M2.a'), 
+             ('M2.b', 'L3.a')]),
+        }
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        input_path = os.path.join(td, 'input.yaml')
+        output_path = os.path.join(td, 'output.yaml')
+        wip_dir = os.path.join(td, 'wip')
+
+        with open(input_path, 'w') as f:
+            yaml.dump(INPUT_DATA, f)
+        
+        result = runner.invoke(
+            main,
+            [
+                'enumerate-assemblies',
+                str(input_path), str(output_path), 
+                '--wip-dir', str(wip_dir), 
+                '--overwrite', '--verbose']
+        )
+
+        assert result.exit_code == 0
+        assert os.path.exists(output_path)
+
+        with open(output_path, 'r') as f:
+            actual_output = yaml.safe_load(f)
+
+        for key, assembly in EXPECTED.items():
+            assert is_isomorphic(
+                actual_output[key], assembly, 
+                INPUT_DATA['component_kinds'])  # type: ignore
 
 
 def test_enum_bond_subsets(tmp_path):


### PR DESCRIPTION
This pull request introduces a new command to enumerate assemblies in the `recsa` CLI and adds corresponding tests. The key changes involve adding the new command, updating the main CLI entry point, and creating tests to ensure the new functionality works correctly.

New command addition:

* [`recsa/cli/commands.py`](diffhunk://#diff-6072a1e48e56829533f6f647cec7986c8c3182d85118c8564ccafb73d7a2f0ecL4-R38): Added the `enumerate-assemblies` command to the CLI, including options for input, output, working directory, overwrite, and verbosity.

Main CLI updates:

* [`recsa/cli/main.py`](diffhunk://#diff-4af3bf0b112be3175aecd49a387a5927c66373d1875e230363a8efd07303c396R4): Imported the `run_enum_assemblies_pipeline` function and added it to the `main` command group. [[1]](diffhunk://#diff-4af3bf0b112be3175aecd49a387a5927c66373d1875e230363a8efd07303c396R4) [[2]](diffhunk://#diff-4af3bf0b112be3175aecd49a387a5927c66373d1875e230363a8efd07303c396R15)

Testing:

* [`recsa/cli/tests/test_assembly_enumeration.py`](diffhunk://#diff-d2e6355494a8206953d8ae119d260a3721b06d53731d3c118cc2a6e320ac76a2R1-R111): Added a new test file with fixtures and a test function to validate the `enumerate-assemblies` command.
* [`recsa/cli/tests/test_main.py`](diffhunk://#diff-5959c8dd8d812378f45cdde07b3305907e395a2c32aeed87e1a8466a29f47608L7-R107): Added a test function to the main test file to ensure the `enumerate-assemblies` command works as expected when invoked from the main CLI entry point.