### PR TITLE
Add support for predefined non-isomorphic groups in assembly grouping

### DIFF
--- a/recsa/duplicate_exclusion/lib/grouping_by_isomorphism.py
+++ b/recsa/duplicate_exclusion/lib/grouping_by_isomorphism.py
@@ -14,7 +14,9 @@ _T = TypeVar('_T', bound=Hashable)
 
 def group_assemblies_by_isomorphism(
         id_to_assembly: Mapping[_T, Assembly],
-        component_structures: Mapping[str, Component]
+        component_structures: Mapping[str, Component],
+        *,
+        non_isomorphic_groups: Iterable[set[_T]] | None = None
         ) -> dict[_T, set[_T]]:
     """Group duplicates by assembly isomorphism.
 
@@ -22,8 +24,13 @@ def group_assemblies_by_isomorphism(
     ----------
     id_to_assembly : Mapping[_T, Assembly]
         A mapping from IDs to assemblies.
-    component_structures : Mapping[str, ComponentStructure]
+    component_structures : Mapping[str, Component]
         A mapping from component kinds to component structures.
+    non_isomorphic_groups : Iterable[set[_T]], optional
+        Predefined groups of assemblies that are guaranteed to be unique
+        and non-isomorphic. Assemblies in the same group will not be 
+        checked for isomorphism. If None, all assemblies are checked for 
+        isomorphism.
 
     Returns
     -------
@@ -31,19 +38,36 @@ def group_assemblies_by_isomorphism(
         A mapping from unique IDs to sets of duplicate IDs.
         Unique IDs are the minimum IDs in each group.
         Duplicate IDs include the unique IDs themselves.
+
+    Notes
+    -----
+    The parameter `non_isomorphic_groups` is useful when there are
+    assemblies that are known to be unique and non-isomorphic. This
+    can be used to reduce the number of isomorphism checks, which can
+    be computationally expensive.
     """
     hash_to_ids = group_assemblies_by_hash(id_to_assembly, component_structures)
+    
+    if non_isomorphic_groups is not None:
+        id_to_non_isomorphic_group = {
+            id_: group for group in non_isomorphic_groups for id_ in group}
 
     uf = UnionFind(id_to_assembly.keys())
 
-    for hash_, ids in hash_to_ids.items():
-        if len(ids) == 1:
+    for hash_, same_hash_ids in hash_to_ids.items():
+        if len(same_hash_ids) == 1:
             continue
 
-        for id1, id2 in combinations(ids, 2):
-            if uf[id1] == uf[id2]:
+        for id1, id2 in combinations(same_hash_ids, 2):
+            if uf[id1] == uf[id2]:  # Already checked to be isomorphic
                 continue
-            if is_isomorphic(
+            if non_isomorphic_groups is not None:
+                non_isom_group1 = id_to_non_isomorphic_group.get(id1)
+                non_isom_group2 = id_to_non_isomorphic_group.get(id2)
+                if non_isom_group1 is not None and non_isom_group1 == non_isom_group2:
+                    # Already guaranteed to be non-isomorphic
+                    continue
+            if is_isomorphic(  # Need isomorphism check
                     id_to_assembly[id1], id_to_assembly[id2],
                     component_structures):
                 uf.union(id1, id2)

--- a/recsa/duplicate_exclusion/lib/tests/test_grouping_by_isomorphism.py
+++ b/recsa/duplicate_exclusion/lib/tests/test_grouping_by_isomorphism.py
@@ -37,5 +37,54 @@ def test_group_assemblies_by_isomorphism():
     }
 
 
+def test_group_assemblies_by_isomorphism_with_non_isomorphic_groups():
+    id_to_graph = {
+        0: Assembly(  # MLX
+            {'M1': 'M', 'L1': 'L', 'X1': 'X'}, 
+            [('M1.a', 'L1.a'), ('M1.b', 'X1.a')]),
+        1: Assembly(  # MLX
+            {'M2': 'M', 'L2': 'L', 'X2': 'X'}, 
+            [('M2.a', 'L2.a'), ('M2.b', 'X2.a')]),
+        2: Assembly(  # MLX
+            {'M3': 'M', 'L3': 'L', 'X3': 'X'}, 
+            [('M3.a', 'L3.a'), ('M3.b', 'X3.a')]),
+        3: Assembly(  # MX2
+            {'M1': 'M', 'X1': 'X', 'X2': 'X'}, 
+            [('M1.a', 'X1.a'), ('M1.b', 'X2.a')]),
+        4: Assembly(  # MX2
+            {'M1': 'M', 'X1': 'X', 'X2': 'X'}, 
+            [('M1.a', 'X1.a'), ('M1.b', 'X2.a')]),
+        5: Assembly(  # L
+            {'L1': 'L'}, 
+            []),
+        6: Assembly(  # L
+            {'L1': 'L'}, 
+            []),
+    }
+    component_structures = {
+        'M': Component({'a', 'b'}),
+        'L': Component({'a', 'b'}),
+        'X': Component({'a'}),
+    }
+    non_isomorphic_groups = [{0, 1, 2}, {3, 4}]
+
+    grouped_ids = group_assemblies_by_isomorphism(id_to_graph, component_structures, non_isomorphic_groups=non_isomorphic_groups)
+
+    assert grouped_ids == {
+        # Although 0, 1, 2 are isomorphic, since they are in the same
+        # non-isomorphic group, their isomorphism check is skipped, thus
+        # they are grouped to different isomorphic groups.
+        0: {0},
+        1: {1},
+        2: {2},
+        # The same applies to 3, 4.
+        3: {3},
+        4: {4},
+        # 5, 6 are not in any non-isomorphic group, so they are checked
+        # for isomorphism. They are isomorphic, so they are grouped together.
+        5: {5, 6},
+    }
+
+
 if __name__ == '__main__':
     pytest.main(['-vv', __file__])


### PR DESCRIPTION
This pull request introduces a new feature to the `group_assemblies_by_isomorphism` function in `grouping_by_isomorphism.py` and adds a corresponding test in `test_grouping_by_isomorphism.py`. The main change allows predefined groups of non-isomorphic assemblies to be passed in, which helps optimize the isomorphism checks by skipping known unique groups.

### Changes to `group_assemblies_by_isomorphism` function:

* Added a new optional parameter `non_isomorphic_groups` to the `group_assemblies_by_isomorphism` function. This parameter allows predefined groups of assemblies that are known to be non-isomorphic to be passed in. Assemblies in the same group will not be checked for isomorphism, reducing computational cost.
* Updated the function logic to handle the new `non_isomorphic_groups` parameter, including creating a mapping from IDs to their respective non-isomorphic groups and modifying the isomorphism check loop to skip checks for assemblies in the same non-isomorphic group.

### New test case:

* Added a new test function `test_group_assemblies_by_isomorphism_with_non_isomorphic_groups` in `test_grouping_by_isomorphism.py` to verify the functionality of the `non_isomorphic_groups` parameter. This test ensures that assemblies in predefined non-isomorphic groups are not checked for isomorphism and are grouped correctly.