### PR TITLE
Add command to concatenate assembly lists and implement associated tests

### DIFF
--- a/recsa/cli/commands.py
+++ b/recsa/cli/commands.py
@@ -1,8 +1,9 @@
 import click
 
-from recsa.pipelines import (bondsets_to_assemblies_pipeline,
-                             enum_bond_subsets_pipeline,
-                             enumerate_assemblies_pipeline)
+from recsa.pipelines import (
+    bondsets_to_assemblies_pipeline,
+    concatenate_assemblies_excluding_duplicates_pipeline,
+    enum_bond_subsets_pipeline, enumerate_assemblies_pipeline)
 
 
 @click.command('enumerate-assemblies')
@@ -36,6 +37,48 @@ def run_enum_assemblies_pipeline(input, output, wip_dir, overwrite, verbose):
     enumerate_assemblies_pipeline(
         input, output,
         wip_dir=wip_dir, overwrite=overwrite, verbose=verbose)
+
+
+@click.command('concat-assembly-lists')
+@click.argument('assemblies', type=click.Path(exists=True), nargs=-1)
+@click.argument('component_kinds', type=click.Path(exists=True))
+@click.argument('output', type=click.Path())
+@click.option(
+    '--already-unique-within-files', '-u', is_flag=True,
+    help='Whether the assemblies in each file are already unique. If used, the isomorphism checks are skipped for the assemblies within each file.')
+@click.option(
+    '--start', '-s', type=int, default=0,
+    help='Starting index for the reindexing of the assemblies.')
+@click.option(
+    '--overwrite', '-o', is_flag=True,
+    help='Overwrite output file if it exists.')
+@click.option(
+    '--verbose', '-v', is_flag=True,
+    help='Print verbose output.')
+def run_concat_assembly_lists_pipeline(
+        assemblies, component_kinds, output, already_unique_within_files, 
+        start, overwrite, verbose):
+    """Concatenates assembly lists.
+
+    \b
+    Parameters
+    ----------
+    - ASSEMBLIES: Paths to input files of assemblies.
+    - COMPONENT_KINDS: Path to input file of component kinds.
+    - OUTPUT: Path to output file.
+
+    \b
+    Options
+    -------
+    --already-unique-within-files, -u: Whether the assemblies in each file are already unique. If used, the isomorphism checks are skipped for the assemblies within each file.
+    --start, -s: Starting index for the reindexing of the assemblies.
+    --overwrite, -o: Overwrite output file if it exists.
+    --verbose, -v: Print verbose output.
+    """
+    concatenate_assemblies_excluding_duplicates_pipeline(
+        assemblies, component_kinds, output,
+        already_unique_within_files=already_unique_within_files,
+        start=start, overwrite=overwrite, verbose=verbose)
 
 
 @click.command('enumerate-bond-subsets')

--- a/recsa/cli/main.py
+++ b/recsa/cli/main.py
@@ -1,6 +1,7 @@
 import click
 
 from recsa.cli.commands import (run_bondsets_to_assemblies_pipeline,
+                                run_concat_assembly_lists_pipeline,
                                 run_enum_assemblies_pipeline,
                                 run_enum_bond_subsets_pipeline)
 
@@ -11,6 +12,7 @@ def main():
     pass
 
 main.add_command(run_enum_bond_subsets_pipeline)
+main.add_command(run_concat_assembly_lists_pipeline)
 main.add_command(run_bondsets_to_assemblies_pipeline)
 main.add_command(run_enum_assemblies_pipeline)
 

--- a/recsa/cli/tests/test_concat.py
+++ b/recsa/cli/tests/test_concat.py
@@ -1,0 +1,74 @@
+import os
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from recsa import Assembly, Component
+from recsa.cli.commands import run_concat_assembly_lists_pipeline
+
+
+@pytest.fixture
+def assemblies_data():
+    return [
+        {
+            0: Assembly({'L1': 'L', 'M1': 'M'}, [('L1.b', 'M1.a')]),
+            1: Assembly({'L2': 'L', 'M2': 'M'}, [('L2.b', 'M2.a')])
+        },
+        {
+            2: Assembly({'L3': 'L', 'M3': 'M'}, [('L3.b', 'M3.a')]),
+            3: Assembly({'L4': 'L', 'M4': 'M'}, [('L4.b', 'M4.a')])
+        }
+    ]
+
+
+@pytest.fixture
+def components_data():
+    return {
+        'component_kinds': {
+            'L': Component({'a', 'b'}),
+            'M': Component({'a', 'b'})
+        }
+    }
+
+
+@pytest.fixture
+def expected_concatenated_assemblies():
+    return {
+        0: Assembly({'L1': 'L', 'M1': 'M'}, [('L1.b', 'M1.a')]),
+    }
+
+
+def test_run_concat_assembly_lists_pipeline(tmp_path, assemblies_data, components_data, expected_concatenated_assemblies):
+    runner = CliRunner()
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        assemblies_paths = []
+        for i, data in enumerate(assemblies_data):
+            path = os.path.join(td, f'assemblies_{i}.yaml')
+            with open(path, 'w') as f:
+                yaml.dump(data, f)
+            assemblies_paths.append(path)
+
+        components_path = os.path.join(td, 'components.yaml')
+        with open(components_path, 'w') as f:
+            yaml.dump(components_data, f)
+
+        output_path = os.path.join(td, 'output.yaml')
+
+        result = runner.invoke(
+            run_concat_assembly_lists_pipeline,
+            [*assemblies_paths, components_path, output_path]
+        )
+
+        assert result.exit_code == 0
+        assert os.path.exists(output_path)
+
+        with open(output_path, 'r') as f:
+            actual_output = yaml.safe_load(f)
+
+        assert actual_output == expected_concatenated_assemblies
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces a new command to concatenate assembly lists and includes the necessary changes to integrate and test this new functionality. The most important changes are summarized below:

### New Command Addition:

* [`recsa/cli/commands.py`](diffhunk://#diff-6072a1e48e56829533f6f647cec7986c8c3182d85118c8564ccafb73d7a2f0ecR42-R83): Added the `run_concat_assembly_lists_pipeline` command to concatenate assembly lists, including options for handling uniqueness, starting index, overwriting output, and verbosity.

### Integration of New Command:

* [`recsa/cli/main.py`](diffhunk://#diff-4af3bf0b112be3175aecd49a387a5927c66373d1875e230363a8efd07303c396R4): Integrated the new `run_concat_assembly_lists_pipeline` command into the CLI by importing it and adding it to the main command group. [[1]](diffhunk://#diff-4af3bf0b112be3175aecd49a387a5927c66373d1875e230363a8efd07303c396R4) [[2]](diffhunk://#diff-4af3bf0b112be3175aecd49a387a5927c66373d1875e230363a8efd07303c396R15)

### Testing:

* [`recsa/cli/tests/test_concat.py`](diffhunk://#diff-b01693b45bb06621b34911b9ca08da656612f3c70430faf8a0aa7e7bd63640b6R1-R74): Added a new test file to verify the functionality of the `run_concat_assembly_lists_pipeline` command, including fixtures for test data and a test case to check the correctness of the concatenated output.