### PR TITLE
Add chain_map utility and corresponding tests

### DIFF
--- a/recsa/utils/__init__.py
+++ b/recsa/utils/__init__.py
@@ -1,3 +1,4 @@
+from .chain_map import *
 from .circular_perm_comparison import *
 from .cyclic_perm import *
 from .frozen_unordered_pair import *

--- a/recsa/utils/chain_map.py
+++ b/recsa/utils/chain_map.py
@@ -1,0 +1,62 @@
+from collections.abc import Mapping
+from functools import reduce
+
+
+def resolve_chain_map(*maps: Mapping) -> Mapping:
+    """
+    Resolve a chain of mappings into one.
+
+    Parameters
+    ----------
+    *maps : Mapping
+        Mappings to resolve.
+
+    Returns
+    -------
+    Mapping
+        The resolved mapping.
+
+    Examples
+    --------
+    >>> input1 = {1: 10, 2: 20}
+    >>> input2 = {10: 100, 20: 200}
+    >>> input3 = {100: 1000, 200: 2000}
+    >>> resolve_chain_map(input1, input2, input3)
+    {1: 1000, 2: 2000}
+
+    >>> resolve_chain_map()
+    {}
+
+    >>> resolve_chain_map({1: 10})
+    {1: 10}
+    """
+    if not maps:
+        return {}
+
+    return reduce(
+        lambda x, y: {k: x[v] for k, v in y.items()}, 
+        reversed(maps))
+
+    # ==============================
+    # Explanation of the logic:
+
+    # Example:
+    # m1 = {1: 10, 2: 20}
+    # m2 = {10: 100, 20: 200}
+    # m3 = {100: 1000, 200: 2000}
+
+    # The following code:
+    # ```
+    # reduce(
+    #     lambda x, y: {k: x[v] for k, v in y.items()},
+    #     [m3, m2, m1])
+    # ```
+    # is equivalent to:
+    # ```
+    # x = m3  # {100: 1000, 200: 2000}
+    # y = m2  # {10: 100, 20: 200}
+    # result = {k: x[v] for k, v in y.items()}  # {10: 1000, 20: 2000}
+    # x = result  # {10: 1000, 20: 2000}
+    # y = m1  # {1: 10, 2: 20}
+    # result = {k: x[v] for k, v in y.items()}  # {1: 1000, 2: 2000}
+    # ```

--- a/recsa/utils/tests/test_chain_map.py
+++ b/recsa/utils/tests/test_chain_map.py
@@ -1,0 +1,27 @@
+import pytest
+
+from recsa.utils import resolve_chain_map
+
+
+def test_basic():
+    input1 = {1: 10, 2: 20}
+    input2 = {10: 100, 20: 200}
+    input3 = {100: 1000, 200: 2000}
+
+    output = resolve_chain_map(input1, input2, input3)
+    assert output == {1: 1000, 2: 2000}
+
+
+def test_empty():
+    output = resolve_chain_map()
+    assert output == {}
+
+
+def test_single_input():
+    input1 = {1: 10}
+    output = resolve_chain_map(input1)
+    assert output == {1: 10}
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces a new utility function `resolve_chain_map` to the `recsa/utils` module and includes corresponding tests. The most important changes include the implementation of the `resolve_chain_map` function, the addition of imports in `__init__.py`, and the creation of tests to verify the new functionality.

### New utility function:

* [`recsa/utils/chain_map.py`](diffhunk://#diff-62f571e3951212f7a90ee158d499b4867e351bb57d75fd72fbe1c7a80c62a3fdR1-R62): Added the `resolve_chain_map` function, which resolves a chain of mappings into one. This function uses the `reduce` function from `functools` and the `Mapping` type from `collections.abc`.

### Initialization changes:

* [`recsa/utils/__init__.py`](diffhunk://#diff-fe151ada519bd210d4b01bb37b69f794542ff851ed38795c60492b42c20fdfd6R1): Added import for all functions from `chain_map.py` to make them accessible from the `recsa.utils` module.

### Tests:

* [`recsa/utils/tests/test_chain_map.py`](diffhunk://#diff-2bb1d3480ef3f59d3452a0f80f05775305732d272bbb99b3fd0a249f347a8e68R1-R27): Added tests for the `resolve_chain_map` function, including tests for basic functionality, empty input, and single input cases.