### PR TITLE
Update sym. op. input format and allow definition by op. chain

### DIFF
--- a/recsa/cli/tests/test_assembly_enumeration.py
+++ b/recsa/cli/tests/test_assembly_enumeration.py
@@ -18,11 +18,8 @@ def input_data():
             3: [2, 4],
             4: [3],
         },
-        'sym_ops_by_bond_maps': {
+        'sym_ops': {
             'C2': {1: 4, 2: 3, 3: 2, 4: 1}
-        },
-        'sym_ops_by_bond_perms': {
-            'C2': [[1, 4], [2, 3]]
         },
         'component_kinds': {
             'L': Component(['a', 'b']),

--- a/recsa/cli/tests/test_bondset_enumeration.py
+++ b/recsa/cli/tests/test_bondset_enumeration.py
@@ -18,7 +18,7 @@ def test_cli_command_a(tmp_path):
             3: {2, 4},
             4: {3},
         },
-        'sym_ops_by_bond_maps': {
+        'sym_ops': {
             'C2': {1: 4, 2: 3, 3: 2, 4: 1}
         }
     }

--- a/recsa/cli/tests/test_main.py
+++ b/recsa/cli/tests/test_main.py
@@ -19,11 +19,8 @@ def test_enumerate_assemblies(tmp_path):
             3: [2, 4],
             4: [3],
         },
-        'sym_ops_by_bond_maps': {
+        'sym_ops': {
             'C2': {1: 4, 2: 3, 3: 2, 4: 1}
-        },
-        'sym_ops_by_bond_perms': {
-            'C2': [[1, 4], [2, 3]]
         },
         'component_kinds': {
             'L': Component(['a', 'b']),
@@ -115,7 +112,7 @@ def test_enum_bond_subsets(tmp_path):
             2: {1, 3},
             3: {2, 4},
             4: {3}},
-        'sym_ops_by_bond_maps': {
+        'sym_ops': {
             'C2': {1: 4, 2: 3, 3: 2, 4: 1}
         }
     }

--- a/recsa/pipelines/tests/test_assembly_enumeration.py
+++ b/recsa/pipelines/tests/test_assembly_enumeration.py
@@ -16,11 +16,8 @@ def test_basic(tmp_path):
             3: {2, 4},
             4: {3},
         },
-        'sym_ops_by_bond_maps': {
+        'sym_ops': {
             'C2': {1: 4, 2: 3, 3: 2, 4: 1}
-        },
-        'sym_ops_by_bond_perms': {
-            'C2': [[1, 4], [2, 3]]
         },
         'component_kinds': {
             'L': Component(['a', 'b']),

--- a/recsa/pipelines/tests/test_bondset_enumeration/test_enum_bond_subsets_pipline.py
+++ b/recsa/pipelines/tests/test_bondset_enumeration/test_enum_bond_subsets_pipline.py
@@ -48,7 +48,7 @@ def test_with_sym_ops(tmp_path):
             3: {2, 4},
             4: {3},
         },
-        'sym_ops_by_bond_maps': {
+        'sym_ops': {
             'C2': {1: 4, 2: 3, 3: 2, 4: 1}
         }
     }

--- a/recsa/pipelines/tests/test_bondset_enumeration/test_parse_sym_ops.py
+++ b/recsa/pipelines/tests/test_bondset_enumeration/test_parse_sym_ops.py
@@ -5,9 +5,7 @@ from recsa.pipelines.bondset_enumeration import parse_sym_ops
 
 def test_with_sym_maps():
     input_data = {
-        'sym_ops_by_bond_maps': {
-            'C2': {1: 4, 2: 3, 3: 2, 4: 1}
-        }
+        'C2': {1: 4, 2: 3, 3: 2, 4: 1}
     }
     expected = {
         'C2': {1: 4, 2: 3, 3: 2, 4: 1}
@@ -17,9 +15,7 @@ def test_with_sym_maps():
 
 def test_with_sym_perms():
     input_data = {
-        'sym_ops_by_bond_perms': {
-            'C3': [[1, 2, 3]]
-        }
+        'C3': [[1, 2, 3]]
     }
     expected = {
         'C3': {1: 2, 2: 3, 3: 1}
@@ -29,23 +25,53 @@ def test_with_sym_perms():
 
 def test_with_both_sym_maps_and_sym_perms():
     input_data = {
-        'sym_ops_by_bond_maps': {
-            'C2': {1: 4, 2: 3, 3: 2, 4: 1}
-        },
-        'sym_ops_by_bond_perms': {
-            'C3': [[1, 2, 3]]
-        }
+        'C2': {1: 4, 2: 3, 3: 2, 4: 1},
+        'C3': [[1, 2, 3]]
     }
     # sym_maps should be prioritized
     expected = {
-        'C2': {1: 4, 2: 3, 3: 2, 4: 1}
+        'C2': {1: 4, 2: 3, 3: 2, 4: 1},
+        'C3': {1: 2, 2: 3, 3: 1}
     }
     assert parse_sym_ops(input_data) == expected
 
 
 def test_with_no_sym_ops():
     input_data = {}  # type: ignore
-    assert parse_sym_ops(input_data) is None
+    assert parse_sym_ops(input_data) == {}
+
+
+def test_op_chain():
+    input_data = {
+        'op1': {1: 2, 2: 3, 3: 1},
+        'op2': {1: 1, 2: 3, 3: 2},
+        'op3': ['op2', 'op1']  # op2(op1(x))
+    }
+
+    expected = {
+        'op1': {1: 2, 2: 3, 3: 1},
+        'op2': {1: 1, 2: 3, 3: 2},
+        'op3': {1: 3, 2: 2, 3: 1},  # op2(op1(x))
+    }
+    assert parse_sym_ops(input_data) == expected
+
+
+def test_chain_of_op_chain():
+    input_data = {
+        'op1': {1: 2, 2: 3, 3: 1},
+        'op2': {1: 1, 2: 3, 3: 2},
+        'op3': ['op2', 'op1'],
+        'op4': ['op1', 'op3']  # op1(op3(x)) = op1(op2(op1(x)))
+    }
+
+    expected = {
+        'op1': {1: 2, 2: 3, 3: 1},
+        'op2': {1: 1, 2: 3, 3: 2},
+        'op3': {1: 3, 2: 2, 3: 1},  # op2(op1(x))
+        'op4': {1: 1, 2: 3, 3: 2},  # op1(op3(x))
+    }
+    assert parse_sym_ops(input_data) == expected
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request includes significant changes to the handling of symmetry operations in the `recsa` package, particularly in the `bondset_enumeration` pipeline. The changes simplify the input data format and enhance the functionality for defining and resolving symmetry operations. The most important changes include modifying the structure of symmetry operations, updating the parsing logic, and adjusting the corresponding tests.

Changes to symmetry operations handling:

* [`recsa/pipelines/bondset_enumeration.py`](diffhunk://#diff-704b7f75f91ab30ef6438b6e5eae64b9d529d80cb4bf4eb60816a026c67f4adeL2-R7): Replaced `sym_ops_by_bond_maps` and `sym_ops_by_bond_perms` with a unified `sym_ops` structure that supports mappings, cyclic permutations, and chains of operations. Updated the `enum_bond_subsets_pipeline` function to accommodate this new structure and added logic to parse and resolve chain operations. [[1]](diffhunk://#diff-704b7f75f91ab30ef6438b6e5eae64b9d529d80cb4bf4eb60816a026c67f4adeL2-R7) [[2]](diffhunk://#diff-704b7f75f91ab30ef6438b6e5eae64b9d529d80cb4bf4eb60816a026c67f4adeL89-R97) [[3]](diffhunk://#diff-704b7f75f91ab30ef6438b6e5eae64b9d529d80cb4bf4eb60816a026c67f4adeL105-L108) [[4]](diffhunk://#diff-704b7f75f91ab30ef6438b6e5eae64b9d529d80cb4bf4eb60816a026c67f4adeL130-R133) [[5]](diffhunk://#diff-704b7f75f91ab30ef6438b6e5eae64b9d529d80cb4bf4eb60816a026c67f4adeL178-R235)

Updates to tests:

* `recsa/cli/tests/test_assembly_enumeration.py`, `recsa/cli/tests/test_bondset_enumeration.py`, `recsa/cli/tests/test_main.py`, `recsa/pipelines/tests/test_assembly_enumeration.py`, and `recsa/pipelines/tests/test_bondset_enumeration/test_enum_bond_subsets_pipline.py`: Modified test cases to use the new `sym_ops` structure. [[1]](diffhunk://#diff-d2e6355494a8206953d8ae119d260a3721b06d53731d3c118cc2a6e320ac76a2L21-L26) [[2]](diffhunk://#diff-23c435ebb228025698410b8e7adbbd968a3e30a472f363458c06414bce43d7a1L21-R21) [[3]](diffhunk://#diff-5959c8dd8d812378f45cdde07b3305907e395a2c32aeed87e1a8466a29f47608L22-L27) [[4]](diffhunk://#diff-5959c8dd8d812378f45cdde07b3305907e395a2c32aeed87e1a8466a29f47608L118-R115) [[5]](diffhunk://#diff-1de7a9a9eec8d4b571c257d2196d7f23700faf9f9c43a5b9ea07a6cecf681885L19-L24) [[6]](diffhunk://#diff-e55fd11ac3b1478f8b1ae1d8aefffba430a66dc1c5150bd4c0ba1ca6778dd98eL51-R51)

Enhancements to symmetry operations parsing tests:

* [`recsa/pipelines/tests/test_bondset_enumeration/test_parse_sym_ops.py`](diffhunk://#diff-cced9fdd3b94fcf10a5830dac1283056607783068a5e4179c448fa1f8f848b7eL8-L11): Updated tests to reflect the new `sym_ops` structure and added new test cases for chain operations and chains of chain operations. [[1]](diffhunk://#diff-cced9fdd3b94fcf10a5830dac1283056607783068a5e4179c448fa1f8f848b7eL8-L11) [[2]](diffhunk://#diff-cced9fdd3b94fcf10a5830dac1283056607783068a5e4179c448fa1f8f848b7eL20-L23) [[3]](diffhunk://#diff-cced9fdd3b94fcf10a5830dac1283056607783068a5e4179c448fa1f8f848b7eL32-R74)