### PR TITLE
Feature/output resolved sym ops

### DIFF
--- a/recsa/pipelines/assembly_enumeration.py
+++ b/recsa/pipelines/assembly_enumeration.py
@@ -24,6 +24,7 @@ def enumerate_assemblies_pipeline(
             wip_dir = temp_dir
         wip_dir = Path(wip_dir)
 
+        resolved_sym_ops_path = wip_dir / 'resolved_sym_ops.yaml'
         wip1_bondsets_path = wip_dir / 'wip1_bondsets.yaml'
         wip2_assemblies_path = wip_dir / 'wip2_assemblies.yaml'
         wip3_unique_assemblies_path = wip_dir / 'wip3_unique_assemblies.yaml'
@@ -33,7 +34,8 @@ def enumerate_assemblies_pipeline(
             print('Enumerating assemblies...')
             
         enum_bond_subsets_pipeline(
-            input_path, wip1_bondsets_path, overwrite=overwrite)
+            input_path, wip1_bondsets_path, overwrite=overwrite,
+            path_to_output_resolved_sym_ops=resolved_sym_ops_path)
         bondsets_to_assemblies_pipeline(
             wip1_bondsets_path, input_path, wip2_assemblies_path,
             overwrite=overwrite)

--- a/recsa/pipelines/bondset_enumeration.py
+++ b/recsa/pipelines/bondset_enumeration.py
@@ -19,7 +19,8 @@ def enum_bond_subsets_pipeline(
         output_path: os.PathLike | str,
         *,
         overwrite: bool = False,
-        verbose: bool = False
+        verbose: bool = False,
+        resolved_sym_ops: os.PathLike | str | None = None
         ) -> None:
     """Enumerate bond subsets and save the result to a file.
 
@@ -42,6 +43,9 @@ def enum_bond_subsets_pipeline(
         If True, overwrite the output file if it exists. Default is False.
     verbose : bool, optional
         If True, print detailed execution messages. Default is False.
+    resolved_sym_ops : os.PathLike or str or None, optional
+        If provided, save resolved symmetry operation mappings to the
+        specified file in YAML format. Default is None.
 
     See Also
     --------
@@ -133,6 +137,12 @@ def enum_bond_subsets_pipeline(
         sym_ops = None
     if sym_ops is not None:
         validate_sym_ops(sym_ops, input_data['bonds'])
+    
+    # Save sym_ops to WIP
+    if resolved_sym_ops:
+        write_output(
+            resolved_sym_ops, sym_ops, overwrite=overwrite,
+            verbose=verbose, header='Resolved symmetry operations')
     
     # Main process
     if verbose:

--- a/recsa/pipelines/bondset_enumeration.py
+++ b/recsa/pipelines/bondset_enumeration.py
@@ -20,7 +20,7 @@ def enum_bond_subsets_pipeline(
         *,
         overwrite: bool = False,
         verbose: bool = False,
-        resolved_sym_ops: os.PathLike | str | None = None
+        path_to_output_resolved_sym_ops: os.PathLike | str | None = None
         ) -> None:
     """Enumerate bond subsets and save the result to a file.
 
@@ -139,9 +139,9 @@ def enum_bond_subsets_pipeline(
         validate_sym_ops(sym_ops, input_data['bonds'])
     
     # Save sym_ops to WIP
-    if resolved_sym_ops:
+    if path_to_output_resolved_sym_ops:
         write_output(
-            resolved_sym_ops, sym_ops, overwrite=overwrite,
+            path_to_output_resolved_sym_ops, sym_ops, overwrite=overwrite,
             verbose=verbose, header='Resolved symmetry operations')
     
     # Main process

--- a/recsa/pipelines/tests/test_bondset_enumeration/test_enum_bond_subsets_pipline.py
+++ b/recsa/pipelines/tests/test_bondset_enumeration/test_enum_bond_subsets_pipline.py
@@ -134,5 +134,38 @@ def test_verbose_true(tmp_path, capsys):
         f'Successfully saved to "{output_path}"' in captured.out)
 
 
+def test_wip(tmp_path):
+    INPUT_DATA = {
+        'bonds': [1, 2, 3, 4],
+        'bond_adjacency': {
+            1: {2},
+            2: {1, 3},
+            3: {2, 4},
+            4: {3},
+        },
+        'sym_ops': {
+            'C2': [[1, 4], [2, 3]]
+        }
+    }
+    input_path = tmp_path / "input.yaml"
+    with open(input_path, 'w') as f:
+        yaml.safe_dump(INPUT_DATA, f)
+
+    output_path = tmp_path / "output.yaml"
+    wip_dir = tmp_path / "resolved_sym_ops.yaml"
+    enum_bond_subsets_pipeline(input_path, output_path, resolved_sym_ops=wip_dir)
+
+    assert os.path.exists(wip_dir)
+    assert os.path.isfile(wip_dir)
+
+    EXPECTED = {
+        'C2': {1: 4, 2: 3, 3: 2, 4: 1}
+    }
+    with open(wip_dir, 'r') as f:
+        actual_output = yaml.safe_load(f)
+    
+    assert actual_output == EXPECTED
+
+
 if __name__ == "__main__":
     pytest.main(['-v', __file__])

--- a/recsa/pipelines/tests/test_bondset_enumeration/test_enum_bond_subsets_pipline.py
+++ b/recsa/pipelines/tests/test_bondset_enumeration/test_enum_bond_subsets_pipline.py
@@ -153,7 +153,7 @@ def test_wip(tmp_path):
 
     output_path = tmp_path / "output.yaml"
     wip_dir = tmp_path / "resolved_sym_ops.yaml"
-    enum_bond_subsets_pipeline(input_path, output_path, resolved_sym_ops=wip_dir)
+    enum_bond_subsets_pipeline(input_path, output_path, path_to_output_resolved_sym_ops=wip_dir)
 
     assert os.path.exists(wip_dir)
     assert os.path.isfile(wip_dir)


### PR DESCRIPTION
This pull request includes changes to the `recsa/pipelines` module to enhance the assembly enumeration process by adding support for saving resolved symmetry operations. The key changes involve updating the assembly and bondset enumeration pipelines and adding a new test case.

Enhancements to assembly and bondset enumeration:

* [`recsa/pipelines/assembly_enumeration.py`](diffhunk://#diff-923101afe72b946d68ef3538dbfb76a0afb2268f1732227799fc76beac9aa487R27): Added `resolved_sym_ops_path` to the working directory paths and updated the `enum_bond_subsets_pipeline` call to include `path_to_output_resolved_sym_ops` parameter. [[1]](diffhunk://#diff-923101afe72b946d68ef3538dbfb76a0afb2268f1732227799fc76beac9aa487R27) [[2]](diffhunk://#diff-923101afe72b946d68ef3538dbfb76a0afb2268f1732227799fc76beac9aa487L36-R38)
* [`recsa/pipelines/bondset_enumeration.py`](diffhunk://#diff-704b7f75f91ab30ef6438b6e5eae64b9d529d80cb4bf4eb60816a026c67f4adeL22-R23): Introduced `path_to_output_resolved_sym_ops` parameter to the `enum_bond_subsets_pipeline` function, updated the docstring to describe the new parameter, and added logic to save resolved symmetry operations if the parameter is provided. [[1]](diffhunk://#diff-704b7f75f91ab30ef6438b6e5eae64b9d529d80cb4bf4eb60816a026c67f4adeL22-R23) [[2]](diffhunk://#diff-704b7f75f91ab30ef6438b6e5eae64b9d529d80cb4bf4eb60816a026c67f4adeR46-R48) [[3]](diffhunk://#diff-704b7f75f91ab30ef6438b6e5eae64b9d529d80cb4bf4eb60816a026c67f4adeR141-R146)

Testing:

* [`recsa/pipelines/tests/test_bondset_enumeration/test_enum_bond_subsets_pipline.py`](diffhunk://#diff-e55fd11ac3b1478f8b1ae1d8aefffba430a66dc1c5150bd4c0ba1ca6778dd98eR137-R169): Added a new test case `test_wip` to verify that the resolved symmetry operations are correctly saved to the specified file.