### PR TITLE
Bump version to 0.13.0 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "recsa"
-version = "0.12.0"
+version = "0.13.0"
 description = "Reaction Explorer for Coordination Self-Assembly"
 authors = ["neji-craftsman <142223934+neji-craftsman@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
This pull request includes a version update for the `recsa` project in the `pyproject.toml` file. The version has been incremented from `0.12.0` to `0.13.0`.

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the project version from `0.12.0` to `0.13.0`.