### PR TITLE
Refactor assembly concatenation to introduce isomorphism check option

### DIFF
--- a/recsa/cli/commands.py
+++ b/recsa/cli/commands.py
@@ -1,9 +1,9 @@
 import click
 
-from recsa.pipelines import (
-    bondsets_to_assemblies_pipeline,
-    concatenate_assemblies_excluding_duplicates_pipeline,
-    enum_bond_subsets_pipeline, enumerate_assemblies_pipeline)
+from recsa.pipelines import (bondsets_to_assemblies_pipeline,
+                             concatenate_assemblies_pipeline,
+                             enum_bond_subsets_pipeline,
+                             enumerate_assemblies_pipeline)
 
 
 @click.command('enumerate-assemblies')
@@ -45,7 +45,13 @@ def run_enum_assemblies_pipeline(input, output, wip_dir, overwrite, verbose):
 @click.argument('output', type=click.Path())
 @click.option(
     '--already-unique-within-files', '-u', is_flag=True,
-    help='Whether the assemblies in each file are already unique. If used, the isomorphism checks are skipped for the assemblies within each file.')
+    help='Whether the assemblies in each file are already unique. If used, '
+    'the isomorphism checks are skipped for the assemblies within each file.')
+@click.option(
+    '--skip-isomorphism-checks', '-i', is_flag=True,
+    help='Whether to skip all isomorphism checks. If True, the assemblies '
+    'are concatenated without checking for isomorphism. The resulting list '
+    'may contain duplicate assemblies.')
 @click.option(
     '--start', '-s', type=int, default=0,
     help='Starting index for the reindexing of the assemblies.')
@@ -57,7 +63,7 @@ def run_enum_assemblies_pipeline(input, output, wip_dir, overwrite, verbose):
     help='Print verbose output.')
 def run_concat_assembly_lists_pipeline(
         assemblies, component_kinds, output, already_unique_within_files, 
-        start, overwrite, verbose):
+        skip_isomorphism_checks, start, overwrite, verbose):
     """Concatenates assembly lists.
 
     \b
@@ -71,13 +77,17 @@ def run_concat_assembly_lists_pipeline(
     Options
     -------
     --already-unique-within-files, -u: Whether the assemblies in each file are already unique. If used, the isomorphism checks are skipped for the assemblies within each file.
+    --skip-isomorphism-checks, -i: Whether to skip all isomorphism checks. 
+    If True, the assemblies are concatenated without checking for 
+    isomorphism. The resulting list may contain duplicate assemblies.
     --start, -s: Starting index for the reindexing of the assemblies.
     --overwrite, -o: Overwrite output file if it exists.
     --verbose, -v: Print verbose output.
     """
-    concatenate_assemblies_excluding_duplicates_pipeline(
+    concatenate_assemblies_pipeline(
         assemblies, component_kinds, output,
         already_unique_within_files=already_unique_within_files,
+        skip_isomorphism_checks=skip_isomorphism_checks,
         start=start, overwrite=overwrite, verbose=verbose)
 
 

--- a/recsa/pipelines/__init__.py
+++ b/recsa/pipelines/__init__.py
@@ -1,7 +1,7 @@
 from .assembly_enumeration import enumerate_assemblies_pipeline
 from .assembly_list_concatenation import (
-    concatenate_assemblies_excluding_duplicates_pipeline,
-    concatenate_assemblies_pipeline)
+    concatenate_assemblies_pipeline,
+    concatenate_assemblies_without_isom_checks)
 from .bindsite_capping import cap_bindsites_pipeline
 from .bondset_enumeration import enum_bond_subsets_pipeline
 from .bondset_to_assembly import bondsets_to_assemblies_pipeline

--- a/recsa/pipelines/assembly_enumeration.py
+++ b/recsa/pipelines/assembly_enumeration.py
@@ -4,7 +4,8 @@ from collections.abc import Hashable
 from pathlib import Path
 from typing import TypeVar
 
-from .assembly_list_concatenation import concatenate_assemblies_pipeline
+from .assembly_list_concatenation import \
+    concatenate_assemblies_without_isom_checks
 from .bindsite_capping import cap_bindsites_pipeline
 from .bondset_enumeration import enum_bond_subsets_pipeline
 from .bondset_to_assembly import bondsets_to_assemblies_pipeline
@@ -45,7 +46,7 @@ def enumerate_assemblies_pipeline(
         cap_bindsites_pipeline(
             wip3_unique_assemblies_path, input_path, input_path, wip4_capped_assemblies_path,
             overwrite=overwrite)
-        concatenate_assemblies_pipeline(
+        concatenate_assemblies_without_isom_checks(
             [wip4_capped_assemblies_path], output_path, overwrite=overwrite)
         
 

--- a/recsa/pipelines/tests/test_assembly_list_concatenation copy.py
+++ b/recsa/pipelines/tests/test_assembly_list_concatenation copy.py
@@ -2,8 +2,7 @@ import pytest
 import yaml
 
 from recsa import Assembly
-from recsa.pipelines import \
-    concatenate_assemblies_excluding_duplicates_pipeline
+from recsa.pipelines import concatenate_assemblies_pipeline
 
 
 def test_basic(tmp_path):
@@ -25,7 +24,7 @@ def test_basic(tmp_path):
 
     OUTPUT_PATH = tmp_path / 'concatenated.yaml'
 
-    concatenate_assemblies_excluding_duplicates_pipeline(
+    concatenate_assemblies_pipeline(
         assemblies_path_list=assemblies_paths,
         components_path=components_path,
         resulting_assems_path=str(OUTPUT_PATH),
@@ -56,7 +55,7 @@ def test_duplicates_within_files(tmp_path):
 
     OUTPUT_PATH = tmp_path / 'concatenated.yaml'
 
-    concatenate_assemblies_excluding_duplicates_pipeline(
+    concatenate_assemblies_pipeline(
         assemblies_path_list=assemblies_paths,
         components_path=components_path,
         resulting_assems_path=str(OUTPUT_PATH),
@@ -86,7 +85,7 @@ def test_already_unique_within_files(tmp_path):
 
     OUTPUT_PATH = tmp_path / 'concatenated.yaml'
 
-    concatenate_assemblies_excluding_duplicates_pipeline(
+    concatenate_assemblies_pipeline(
         assemblies_path_list=assemblies_paths,
         components_path=components_path,
         resulting_assems_path=str(OUTPUT_PATH),
@@ -101,6 +100,44 @@ def test_already_unique_within_files(tmp_path):
     # `already_unique_within_files` is set to True, which means that
     # the isomorphism check is skipped for the assemblies within the
     # same file.
+    assert output_data == {
+        0: Assembly({'first': 'L'}), 1: Assembly({'second': 'L'})}
+
+
+def test_skip_isomorphism_checks(tmp_path):
+    assemblies_paths = [
+        tmp_path / 'first.yaml',
+        tmp_path / 'second.yaml']
+    
+    ASSEMBLIES = [
+        {0: Assembly({'first': 'L'})},
+        {0: Assembly({'second': 'L'})}]  # isomorphic to the first one
+    
+    for path, assems in zip(assemblies_paths, ASSEMBLIES):
+        with open(path, 'w') as f:
+            yaml.dump(assems, f)
+
+    components_path = tmp_path / 'components.yaml'
+    with open(components_path, 'w') as f:
+        yaml.dump({'component_kinds': {}}, f)
+
+    OUTPUT_PATH = tmp_path / 'concatenated.yaml'
+
+    concatenate_assemblies_pipeline(
+        assemblies_path_list=assemblies_paths,
+        components_path=components_path,
+        resulting_assems_path=str(OUTPUT_PATH),
+        skip_isomorphism_checks=True,  # This is the only difference
+        start=0, overwrite=True, verbose=False)
+    
+    with open(OUTPUT_PATH, 'r') as f:
+        output_data = yaml.safe_load(f)
+
+    # The second assembly is included even though it is isomorphic to
+    # the first one. This is because the parameter `skip_isomorphism_checks`
+    # is set to True, which means that the isomorphism check is skipped
+    # for all assemblies.
+
     assert output_data == {
         0: Assembly({'first': 'L'}), 1: Assembly({'second': 'L'})}
 

--- a/recsa/pipelines/tests/test_assembly_list_concatenation.py
+++ b/recsa/pipelines/tests/test_assembly_list_concatenation.py
@@ -2,7 +2,7 @@ import pytest
 import yaml
 
 from recsa import Assembly
-from recsa.pipelines import concatenate_assemblies_pipeline
+from recsa.pipelines import concatenate_assemblies_without_isom_checks
 
 
 def test_basic(tmp_path):
@@ -20,7 +20,7 @@ def test_basic(tmp_path):
 
     OUTPUT_PATH = tmp_path / 'concatenated.yaml'
 
-    concatenate_assemblies_pipeline(
+    concatenate_assemblies_without_isom_checks(
         assemblies_path_list=assemblies_paths,
         resulting_assems_path=str(OUTPUT_PATH),
         start=0, overwrite=True, verbose=False)
@@ -47,7 +47,7 @@ def test_paths_order_preservation(tmp_path):
     
     output_path = tmp_path / 'concatenated.yaml'
 
-    concatenate_assemblies_pipeline(
+    concatenate_assemblies_without_isom_checks(
         assemblies_path_list=assemblies_paths,
         resulting_assems_path=str(output_path),
         start=0, overwrite=True, verbose=False)
@@ -79,7 +79,7 @@ def test_assembly_order_preservation(tmp_path):
 
     OUTPUT_PATH = tmp_path / 'concatenated.yaml'
 
-    concatenate_assemblies_pipeline(
+    concatenate_assemblies_without_isom_checks(
         assemblies_path_list=assemblies_paths,
         resulting_assems_path=str(OUTPUT_PATH),
         start=0, overwrite=True, verbose=False)
@@ -104,7 +104,7 @@ def test_start(tmp_path):
 
     OUTPUT_PATH = tmp_path / 'concatenated.yaml'
 
-    concatenate_assemblies_pipeline(
+    concatenate_assemblies_without_isom_checks(
         assemblies_path_list=[filepath],
         resulting_assems_path=str(OUTPUT_PATH),
         start=10, overwrite=True, verbose=False)
@@ -127,7 +127,7 @@ def test_overwrite_true(tmp_path):
     with open(OUTPUT_PATH, 'w') as f:
         yaml.dump('previous data', f)
 
-    concatenate_assemblies_pipeline(
+    concatenate_assemblies_without_isom_checks(
         assemblies_path_list=[filepath],
         resulting_assems_path=str(OUTPUT_PATH),
         start=0, overwrite=True, verbose=False)
@@ -149,7 +149,7 @@ def test_overwrite_false(tmp_path):
         yaml.dump('previous data', f)
 
     with pytest.raises(FileExistsError):
-         concatenate_assemblies_pipeline(
+         concatenate_assemblies_without_isom_checks(
             assemblies_path_list=[filepath],
             resulting_assems_path=str(OUTPUT_PATH),
             start=0, overwrite=False, verbose=False)
@@ -163,7 +163,7 @@ def test_verbose_true(tmp_path, capsys):
     
     OUTPUT_PATH = tmp_path / 'concatenated.yaml'
 
-    concatenate_assemblies_pipeline(
+    concatenate_assemblies_without_isom_checks(
         assemblies_path_list=[filepath],
         resulting_assems_path=str(OUTPUT_PATH),
         start=0, overwrite=True, verbose=True)
@@ -183,7 +183,7 @@ def test_verbose_false(tmp_path, capsys):
     
     OUTPUT_PATH = tmp_path / 'concatenated.yaml'
 
-    concatenate_assemblies_pipeline(
+    concatenate_assemblies_without_isom_checks(
         assemblies_path_list=[filepath],
         resulting_assems_path=str(OUTPUT_PATH),
         start=0, overwrite=True, verbose=False)


### PR DESCRIPTION
This pull request focuses on enhancing the functionality and flexibility of the assembly concatenation pipeline by introducing an option to skip isomorphism checks. The changes include modifying the pipeline functions, updating the corresponding command-line interface (CLI) options, and adjusting the tests to accommodate the new functionality.

Enhancements to the assembly concatenation pipeline:

* [`recsa/cli/commands.py`](diffhunk://#diff-6072a1e48e56829533f6f647cec7986c8c3182d85118c8564ccafb73d7a2f0ecL48-R54): Added a new CLI option `--skip-isomorphism-checks` to the `run_enum_assemblies_pipeline` function, allowing users to skip isomorphism checks during the concatenation of assemblies. [[1]](diffhunk://#diff-6072a1e48e56829533f6f647cec7986c8c3182d85118c8564ccafb73d7a2f0ecL48-R54) [[2]](diffhunk://#diff-6072a1e48e56829533f6f647cec7986c8c3182d85118c8564ccafb73d7a2f0ecL60-R66) [[3]](diffhunk://#diff-6072a1e48e56829533f6f647cec7986c8c3182d85118c8564ccafb73d7a2f0ecR80-R90)
* [`recsa/pipelines/assembly_list_concatenation.py`](diffhunk://#diff-3ce472711d51fcb93bbf151f5a7b468ab652b416b114cee7159feaba6eb39037L3-R38): Introduced the `skip_isomorphism_checks` parameter in the `concatenate_assemblies_pipeline` function and created a new function `concatenate_assemblies_without_isom_checks` to handle cases where isomorphism checks are skipped. [[1]](diffhunk://#diff-3ce472711d51fcb93bbf151f5a7b468ab652b416b114cee7159feaba6eb39037L3-R38) [[2]](diffhunk://#diff-3ce472711d51fcb93bbf151f5a7b468ab652b416b114cee7159feaba6eb39037R55-R68) [[3]](diffhunk://#diff-3ce472711d51fcb93bbf151f5a7b468ab652b416b114cee7159feaba6eb39037R85-R99) [[4]](diffhunk://#diff-3ce472711d51fcb93bbf151f5a7b468ab652b416b114cee7159feaba6eb39037L104-R146)

Codebase simplification:

* [`recsa/pipelines/__init__.py`](diffhunk://#diff-5face669fd17f99ef76de27fa11d6bfa3f654ab42e230ba63754047d4cb81fc6L3-R4): Updated imports to include the new function `concatenate_assemblies_without_isom_checks` and removed the deprecated `concatenate_assemblies_excluding_duplicates_pipeline`.
* [`recsa/pipelines/assembly_enumeration.py`](diffhunk://#diff-923101afe72b946d68ef3538dbfb76a0afb2268f1732227799fc76beac9aa487L7-R8): Modified the `enumerate_assemblies_pipeline` function to use `concatenate_assemblies_without_isom_checks` when skipping isomorphism checks. [[1]](diffhunk://#diff-923101afe72b946d68ef3538dbfb76a0afb2268f1732227799fc76beac9aa487L7-R8) [[2]](diffhunk://#diff-923101afe72b946d68ef3538dbfb76a0afb2268f1732227799fc76beac9aa487L48-R49)

Test updates:

* [`recsa/pipelines/tests/test_assembly_list_concatenation copy.py`](diffhunk://#diff-6232f4d96efdf9393cf49db5a528fdfd12117c639022da5a731879e9c7986510L5-R5): Updated existing tests to use the new `concatenate_assemblies_pipeline` function and added a new test `test_skip_isomorphism_checks` to verify the behavior when isomorphism checks are skipped. [[1]](diffhunk://#diff-6232f4d96efdf9393cf49db5a528fdfd12117c639022da5a731879e9c7986510L5-R5) [[2]](diffhunk://#diff-6232f4d96efdf9393cf49db5a528fdfd12117c639022da5a731879e9c7986510L28-R27) [[3]](diffhunk://#diff-6232f4d96efdf9393cf49db5a528fdfd12117c639022da5a731879e9c7986510L59-R58) [[4]](diffhunk://#diff-6232f4d96efdf9393cf49db5a528fdfd12117c639022da5a731879e9c7986510L89-R88) [[5]](diffhunk://#diff-6232f4d96efdf9393cf49db5a528fdfd12117c639022da5a731879e9c7986510R107-R144)
* [`recsa/pipelines/tests/test_assembly_list_concatenation.py`](diffhunk://#diff-921030a9195f1926b46315229ca543e567f417dc5249397adb009ef2aa6ffc45L5-R5): Adjusted tests to use the `concatenate_assemblies_without_isom_checks` function, ensuring the functionality remains consistent when isomorphism checks are not required. [[1]](diffhunk://#diff-921030a9195f1926b46315229ca543e567f417dc5249397adb009ef2aa6ffc45L5-R5) [[2]](diffhunk://#diff-921030a9195f1926b46315229ca543e567f417dc5249397adb009ef2aa6ffc45L23-R23) [[3]](diffhunk://#diff-921030a9195f1926b46315229ca543e567f417dc5249397adb009ef2aa6ffc45L50-R50) [[4]](diffhunk://#diff-921030a9195f1926b46315229ca543e567f417dc5249397adb009ef2aa6ffc45L82-R82) [[5]](diffhunk://#diff-921030a9195f1926b46315229ca543e567f417dc5249397adb009ef2aa6ffc45L107-R107) [[6]](diffhunk://#diff-921030a9195f1926b46315229ca543e567f417dc5249397adb009ef2aa6ffc45L130-R130) [[7]](diffhunk://#diff-921030a9195f1926b46315229ca543e567f417dc5249397adb009ef2aa6ffc45L152-R152) [[8]](diffhunk://#diff-921030a9195f1926b46315229ca543e567f417dc5249397adb009ef2aa6ffc45L166-R166) [[9]](diffhunk://#diff-921030a9195f1926b46315229ca543e567f417dc5249397adb009ef2aa6ffc45L186-R186)