### PR TITLE
Add entry point for the recsa CLI

### DIFF
--- a/recsa/__main__.py
+++ b/recsa/__main__.py
@@ -1,0 +1,4 @@
+from recsa.cli.main import main
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This pull request includes a small change to the `recsa/__main__.py` file. The change adds an entry point for the program by importing the `main` function from `recsa.cli.main` and calling it if the script is run as the main module.