### PR TITLE
Update script section in pyproject.toml to use the correct format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ twine = "^6.1.0"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[project.scripts]
+[tool.poetry.scripts]
 recsa = "recsa.cli.main:main"
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
This pull request includes a change to the `pyproject.toml` file to update the configuration for project scripts.

Configuration update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L39-R39): Changed `[project.scripts]` to `[tool.poetry.scripts]` to align with the updated Poetry configuration format.