### PR TITLE
Add version option to CLI and corresponding test

### DIFF
--- a/recsa/cli/main.py
+++ b/recsa/cli/main.py
@@ -7,6 +7,7 @@ from recsa.cli.commands import (run_bondsets_to_assemblies_pipeline,
 
 
 @click.group()
+@click.version_option(prog_name='recsa')
 def main():
     """RECSA CLI"""
     pass

--- a/recsa/cli/tests/test_main.py
+++ b/recsa/cli/tests/test_main.py
@@ -8,6 +8,13 @@ from recsa import Assembly, Component, is_isomorphic
 from recsa.cli.main import main
 
 
+def test_version():
+    runner = CliRunner()
+    result = runner.invoke(main, ['--version'])
+    assert result.exit_code == 0
+    assert 'recsa' in result.output
+
+
 def test_enumerate_assemblies(tmp_path):
     runner = CliRunner()
 


### PR DESCRIPTION
This pull request includes a couple of changes to the `recsa` CLI tool. The changes add a version option to the CLI and include a corresponding test to ensure the version option works correctly.

Enhancements to the `recsa` CLI tool:

* [`recsa/cli/main.py`](diffhunk://#diff-4af3bf0b112be3175aecd49a387a5927c66373d1875e230363a8efd07303c396R10): Added a version option to the `recsa` CLI using `@click.version_option(prog_name='recsa')`.
* [`recsa/cli/tests/test_main.py`](diffhunk://#diff-5959c8dd8d812378f45cdde07b3305907e395a2c32aeed87e1a8466a29f47608R11-R17): Added a test case `test_version` to verify that the version option returns the correct program name and exit code.