### PR TITLE
Add properties for number of reactants and products in reaction classes

### DIFF
--- a/recsa/classes/reaction.py
+++ b/recsa/classes/reaction.py
@@ -1,6 +1,6 @@
 from dataclasses import asdict, dataclass
 from functools import cached_property
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 from .assembly import Assembly
 
@@ -20,6 +20,18 @@ class IntraReaction:
         d = asdict(self)
         d['entering_assem_id'] = self.entering_assem_id
         return d
+    
+    @property
+    def num_of_reactants(self) -> Literal[1]:
+        """Number of reactants in the reaction."""
+        return 1
+    
+    @property
+    def num_of_products(self) -> Literal[1, 2]:
+        """Number of products in the reaction."""
+        if self.leaving_assem_id is None:
+            return 1
+        return 2
 
 
 @dataclass
@@ -35,6 +47,18 @@ class InterReaction:
 
     def to_dict(self):
         return asdict(self)
+    
+    @property
+    def num_of_reactants(self) -> Literal[2]:
+        """Number of reactants in the reaction."""
+        return 2
+    
+    @property
+    def num_of_products(self) -> Literal[1, 2]:
+        """Number of products in the reaction."""
+        if self.leaving_assem_id is None:
+            return 1
+        return 2
 
 
 @dataclass(frozen=True)

--- a/recsa/classes/tests/test_reaction.py
+++ b/recsa/classes/tests/test_reaction.py
@@ -1,0 +1,94 @@
+import pytest
+
+from recsa import InterReaction, IntraReaction
+
+
+def test_num_of_reactants():
+    intra_reaction = IntraReaction(
+        init_assem_id=0,
+        product_assem_id=1,
+        leaving_assem_id=None,
+        metal_bs='M0.a',
+        leaving_bs='X0.a',
+        entering_bs='L0.a',
+        duplicate_count=1
+    )
+    inter_reaction = InterReaction(
+        init_assem_id=0,
+        entering_assem_id=1,
+        product_assem_id=2,
+        leaving_assem_id=None,
+        metal_bs='M0.a',
+        leaving_bs='X0.a',
+        entering_bs='L0.a',
+        duplicate_count=1
+    )
+
+    # The number of reactants for intra-reaction should always be 1.
+    assert intra_reaction.num_of_reactants == 1
+    # The number of reactants for inter-reaction should always be 2.
+    assert inter_reaction.num_of_reactants == 2
+
+
+def test_num_of_products_of_intra_reaction():
+    """
+    Test the number of products in IntraReaction and InterReaction classes.
+    """
+    intra_with_leaving = IntraReaction(
+        init_assem_id=0,
+        product_assem_id=1,
+        leaving_assem_id=2,
+        metal_bs='M0.a',
+        leaving_bs='X0.a',
+        entering_bs='L0.a',
+        duplicate_count=1
+    )
+    intra_without_leaving = IntraReaction(
+        init_assem_id=0,
+        product_assem_id=1,
+        leaving_assem_id=None,
+        metal_bs='M0.a',
+        leaving_bs='X0.a',
+        entering_bs='L0.a',
+        duplicate_count=1
+    )
+
+    # The number of products for reactions with leaving assembly should be 2.
+    assert intra_with_leaving.num_of_products == 2
+    # The number of products for reactions without leaving assembly should be 1.
+    assert intra_without_leaving.num_of_products == 1
+
+
+def test_num_of_products_of_inter_reaction():
+    """
+    Test the number of products in IntraReaction and InterReaction classes.
+    """
+    inter_with_leaving = InterReaction(
+        init_assem_id=0,
+        entering_assem_id=1,
+        product_assem_id=2,
+        leaving_assem_id=3,
+        metal_bs='M0.a',
+        leaving_bs='X0.a',
+        entering_bs='L0.a',
+        duplicate_count=1
+    )
+    inter_without_leaving = InterReaction(
+        init_assem_id=0,
+        entering_assem_id=1,
+        product_assem_id=2,
+        leaving_assem_id=None,
+        metal_bs='M0.a',
+        leaving_bs='X0.a',
+        entering_bs='L0.a',
+        duplicate_count=1
+    )
+
+    # The number of products for reactions with leaving assembly should be 2.
+    assert inter_with_leaving.num_of_products == 2
+    # The number of products for reactions without leaving assembly should be 1.
+    assert inter_without_leaving.num_of_products == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
This pull request introduces new properties to the `IntraReaction` and `InterReaction` classes to calculate the number of reactants and products dynamically. Additionally, it includes unit tests to verify the correctness of these properties. Below is a summary of the changes:

### Enhancements to `reaction.py`:

* Added `num_of_reactants` and `num_of_products` properties to the `IntraReaction` class to dynamically determine the number of reactants (always `1`) and products (either `1` or `2` based on the presence of a leaving assembly).
* Added `num_of_reactants` and `num_of_products` properties to the `InterReaction` class to dynamically determine the number of reactants (always `2`) and products (either `1` or `2` based on the presence of a leaving assembly).

### Unit tests for `reaction.py`:

* Created a new test file `test_reaction.py` to validate the `num_of_reactants` and `num_of_products` properties for both `IntraReaction` and `InterReaction` classes. Tests cover scenarios with and without a leaving assembly.