### PR TITLE
Add binding site equivalence function and corresponding tests

### DIFF
--- a/recsa/algorithms/__init__.py
+++ b/recsa/algorithms/__init__.py
@@ -19,6 +19,7 @@ from .assembly_connectivity import extract_connected_assemblies
 from .assembly_equality import assemblies_equal
 from .assembly_separation import separate_product_if_possible
 from .aux_edge_existence import has_aux_edges
+from .bindsite_equivalence import are_equivalent_binding_site_lists
 from .bondset_sorting import sort_bondsets
 from .bondset_sorting import sort_bondsets_and_bonds
 from .hashing import calc_graph_hash_of_assembly

--- a/recsa/algorithms/bindsite_equivalence.py
+++ b/recsa/algorithms/bindsite_equivalence.py
@@ -1,0 +1,59 @@
+from collections.abc import Mapping, Sequence
+from itertools import chain
+
+from recsa import Assembly, Component
+from recsa.algorithms.isomorphism import isomorphisms_iter
+
+
+def are_equivalent_binding_site_lists(
+        assembly: Assembly,
+        binding_site_list1: Sequence[str],
+        binding_site_list2: Sequence[str],
+        component_structures: Mapping[str, Component],
+        ) -> bool:
+    """
+    Check if the pair of binding site lists are equivalent.
+
+    "Equivalent" means that there is at least one isomorphism 
+    which maps each binding site in the first list to a binding site
+    in the second list.
+    The order of the binding sites in the list DOES matter.
+
+    Parameters
+    ----------
+    assembly : Assembly
+        The assembly to which the binding sites belong.
+    binding_site_list1 : Sequence[str]
+        The first list of binding sites.
+    binding_site_list2 : Sequence[str]
+        The second list of binding sites.
+    component_structures : Mapping[str, Component]
+        The component structures of the assembly.
+
+    Returns
+    -------
+    bool
+        True if the binding site lists are equivalent, False otherwise.
+    """
+    # Input validation
+    if len(binding_site_list1) != len(binding_site_list2):
+        raise ValueError(
+            "The length of the binding site lists must be the same.")
+    if not binding_site_list1:
+        raise ValueError("The binding site lists must not be empty.")
+    
+    # Check if the binding sites are in the assembly
+    for bs in chain(binding_site_list1, binding_site_list2):
+        if bs not in assembly.get_all_bindsites(component_structures):
+            raise ValueError(f"Binding site {bs} not found in assembly.")
+
+    # ---
+    # Main logic
+    for isom in isomorphisms_iter(
+            assembly, assembly, component_structures):
+        for (bs1, bs2) in zip(binding_site_list1, binding_site_list2):
+            if isom[bs1] != bs2:
+                break
+        else:
+            return True
+    return False

--- a/recsa/algorithms/tests/test_bindsite_equivalence.py
+++ b/recsa/algorithms/tests/test_bindsite_equivalence.py
@@ -1,0 +1,173 @@
+import pytest
+
+from recsa import Assembly, Component
+from recsa.algorithms import are_equivalent_binding_site_lists
+
+
+@pytest.fixture
+def component_structures():
+    """Fixture for component structures."""
+    return {
+        'M_bi': Component(['a', 'b']),
+        'M_tetra': Component(['a', 'b', 'c', 'd']),
+        'L': Component(['a', 'b']),
+        'X': Component(['a']),
+    }
+
+@pytest.fixture
+def M():
+    # (a)M0(b)
+    return Assembly({'M0': 'M_bi'})
+
+@pytest.fixture
+def ML2():
+    # (a)L0(b)-(a)M0(b)-(a)L1(b)
+    return Assembly(
+        {'M0': 'M_bi', 'L0': 'L', 'L1': 'L'},
+        [('L0.b', 'M0.a'), ('M0.b', 'L1.a')]
+    )
+
+@pytest.fixture
+def MLX():
+    # (a)L0(b)-(a)M0(b)-(a)X0
+    return Assembly(
+        {'M0': 'M_bi', 'L0': 'L', 'X0': 'X'},
+        [('L0.b', 'M0.a'), ('M0.b', 'X0.a')]
+    )
+
+@pytest.fixture
+def ML2X2():
+    #              X0
+    #             (a)
+    #              |
+    #             (c)
+    # (a)L0(b)--(a)M0(b)--(a)L1(b)
+    #             (d)
+    #              |
+    #             (a)
+    #              X1
+
+    # WITHOUT auxiliary edges
+
+    return Assembly(
+        {'M0': 'M_tetra', 'L0': 'L', 'L1': 'L', 'X0': 'X', 'X1': 'X'},
+        [('M0.a', 'L0.b'), ('M0.b', 'L1.b'),
+         ('M0.c', 'X0.a'), ('M0.d', 'X1.a')]
+    )
+
+
+def test_different_lengths_error(M):
+    # Check if ValueError is raised for different lengths
+    with pytest.raises(ValueError):
+        are_equivalent_binding_site_lists(M, ['M0.a'], ['M0.a', 'M0.b'], {})
+
+
+def test_empty_lists_error(M):
+    # Check if ValueError is raised for empty lists
+    with pytest.raises(ValueError):
+        are_equivalent_binding_site_lists(M, [], [], {})
+
+
+def test_nonexistent_binding_site_error(M, component_structures):
+    # Check if ValueError is raised for nonexistent binding sites
+    with pytest.raises(ValueError):
+        are_equivalent_binding_site_lists(
+            M, ['M0.a'], ['M0.unknown'], component_structures)
+    with pytest.raises(ValueError):
+        are_equivalent_binding_site_lists(
+            M, ['M0.unknown'], ['M0.a'], component_structures)
+
+
+def test_single_binding_site(M, component_structures):
+    assert are_equivalent_binding_site_lists(
+        M, ['M0.a'], ['M0.b'], component_structures)
+
+
+def test_assembly_composed_of_multiple_components(
+        ML2, ML2X2, component_structures):
+    assert are_equivalent_binding_site_lists(
+        ML2, ['L0.a'], ['L1.b'], component_structures)
+    assert are_equivalent_binding_site_lists(
+        ML2X2, ['L0.a', 'M0.c'], ['L1.a', 'M0.d'], component_structures)
+
+
+def test_consideration_of_component_kinds(MLX, component_structures):
+    # Should not be equivalent
+    # because isomorphisms which maps L0 to X0 are not allowed.
+    assert not are_equivalent_binding_site_lists(
+        MLX, ['L0.b', 'M0.a'], ['X0.a', 'M0.b'], component_structures)
+
+
+def test_self_comparison(M, ML2, MLX, component_structures):
+    assert are_equivalent_binding_site_lists(
+        M, ['M0.a'], ['M0.a'], component_structures)
+    assert are_equivalent_binding_site_lists(
+        ML2, ['L0.a', 'L0.b'], ['L0.a', 'L0.b'], component_structures)
+    assert are_equivalent_binding_site_lists(
+        MLX, ['L0.a', 'L0.b'], ['L0.a', 'L0.b'], component_structures)
+
+
+def test_pair(ML2, component_structures):
+    # Same binding sites in M
+    assert are_equivalent_binding_site_lists(
+        ML2, ['L0.a', 'L0.b'], ['L1.b', 'L1.a'], component_structures)
+    assert not are_equivalent_binding_site_lists(
+        ML2, ['L0.a', 'L0.b'], ['L1.a', 'L1.b'], component_structures)
+
+
+def test_trio(ML2X2, component_structures):
+    # Consider inter-molecular reactions of ML2X2 as an example.
+    # trio: (metal, leaving, entering)
+    assert are_equivalent_binding_site_lists(
+        ML2X2, ['M0.c', 'X0.a', 'L0.a'], ['M0.d', 'X1.a', 'L1.a'],
+        component_structures)
+
+
+def test_auxiliary_edges():
+    COMPONENT_KINDS = {
+        'M_plain': Component(['a', 'b', 'c', 'd']),
+        'M_aux': Component(
+            ['a', 'b', 'c', 'd'],
+            [('a', 'b', 'cis'), ('b', 'c', 'cis'), 
+             ('c', 'd', 'cis'), ('d', 'a', 'cis')]
+        ),
+        'L': Component(['a', 'b']),
+        'X': Component(['a']),
+    }
+
+    #           X0
+    #          (a)
+    #           |
+    #          (a)
+    # X1(a)--(b)M0(d)--(a)L0(b)
+    #          (c)
+    #           |
+    #          (a)
+    #           X2
+    MLX3_plain = Assembly(
+        {'M0': 'M_plain', 'L0': 'L', 'X0': 'X', 'X1': 'X', 'X2': 'X'},
+        [('M0.a', 'X0.a'), ('M0.b', 'X1.a'),
+         ('M0.c', 'X2.a'), ('M0.d', 'L0.a')]
+        )
+    MLX3_aux = Assembly(
+        {'M0': 'M_aux', 'L0': 'L', 'X0': 'X', 'X1': 'X', 'X2': 'X'},
+        [('M0.a', 'X0.a'), ('M0.b', 'X1.a'),
+         ('M0.c', 'X2.a'), ('M0.d', 'L0.a')]
+        )
+    
+    assert are_equivalent_binding_site_lists(
+        MLX3_plain, ['M0.d', 'M0.a'], ['M0.d', 'M0.b'], COMPONENT_KINDS)
+    assert not are_equivalent_binding_site_lists(
+        MLX3_aux, ['M0.d', 'M0.a'], ['M0.d', 'M0.b'], COMPONENT_KINDS)
+    
+    # Intra-molecular reaction
+    assert are_equivalent_binding_site_lists(
+        MLX3_plain, ['M0.a', 'X0.a', 'L0.b'], ['M0.b', 'X1.a', 'L0.b'],
+        COMPONENT_KINDS)
+    assert not are_equivalent_binding_site_lists(
+        MLX3_aux, ['M0.a', 'X0.a', 'L0.b'], ['M0.b', 'X1.a', 'L0.b'],
+        COMPONENT_KINDS)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
This pull request introduces a new function to check the equivalence of binding site lists and includes comprehensive unit tests to validate its functionality. The changes primarily focus on adding the new functionality, integrating it into the module, and ensuring robust test coverage.

### New functionality:

* Added a new function, `are_equivalent_binding_site_lists`, in `recsa/algorithms/bindsite_equivalence.py`. This function determines if two binding site lists are equivalent by checking for isomorphisms that map each binding site in the first list to a corresponding site in the second list. It includes input validation and detailed error handling.

### Module integration:

* Imported the `are_equivalent_binding_site_lists` function in `recsa/algorithms/__init__.py` to make it accessible as part of the module's public API.

### Test coverage:

* Added a new test file, `recsa/algorithms/tests/test_bindsite_equivalence.py`, containing extensive unit tests for `are_equivalent_binding_site_lists`. These tests cover various scenarios, including:
  - Validation of input lengths and non-empty lists.
  - Handling of nonexistent binding sites.
  - Cases with single binding sites, self-comparison, and complex assemblies.
  - Consideration of auxiliary edges in component structures.