### PR TITLE
Add reaction equivalence checking functionality and corresponding tests

### DIFF
--- a/recsa/algorithms/__init__.py
+++ b/recsa/algorithms/__init__.py
@@ -29,6 +29,7 @@ from .isomorphism import isomorphisms_iter
 from .ligand_exchange import perform_inter_exchange
 from .ligand_exchange import perform_intra_exchange
 from .reaction_embedding import embed_assemblies_into_reaction
+from .reaction_comparison import are_equivalent_reactions
 from .subassembly import bond_induced_sub_assembly
 from .subassembly import component_induced_sub_assembly
 from .union import union_assemblies

--- a/recsa/algorithms/reaction_comparison.py
+++ b/recsa/algorithms/reaction_comparison.py
@@ -1,0 +1,107 @@
+from collections.abc import Mapping
+
+from recsa import Assembly, Component, InterReaction, IntraReaction
+
+from .bindsite_equivalence import are_equivalent_binding_site_lists
+
+
+def are_equivalent_reactions(
+        reaction1: IntraReaction | InterReaction,
+        reaction2: IntraReaction | InterReaction,
+        id_to_assembly: Mapping[int, Assembly],
+        component_structures: Mapping[str, Component],
+        ) -> bool:
+    """
+    Check if two reactions are equivalent.
+
+    Two reactions are equivalent if they meet the following conditions:
+        1-1. They have the same number of reactants.
+        1-2. They have the same number of products.
+        2-1. They have the same initial assembly.
+        2-2. They have the same entering assembly, or both are None.
+        2-3. They have the same product assembly.
+        2-4. They have the same leaving assembly, or both are None.
+        3-1. If the reaction is intra-molecular, the trio of binding sites
+            [metal, leaving, entering] must be equivalent.
+        3-2. If the reaction is inter-molecular, the pair of binding sites
+            [metal, leaving] of the initial assembly must be equivalent,
+            and the entering binding site of the entering assembly must be
+            equivalent to the entering binding site of the other reaction.
+    
+    Here, two binding site lists (e.g. [metal1, leaving1] and 
+    [metal2, leaving2]) are equivalent if there is at least one isomorphism
+    which maps each binding site in the first list to a binding site in 
+    the second list. The order of the binding sites in the list DOES matter.
+    
+    Parameters
+    ----------
+    reaction1 : IntraReaction | InterReaction
+        The first reaction to compare.
+    reaction2 : IntraReaction | InterReaction
+        The second reaction to compare.
+    id_to_assembly : Mapping[int, Assembly]
+        A mapping from assembly IDs to assemblies. This must not include
+        duplicate assemblies since this function only uses the IDs to
+        compare the assemblies, not the assembly structures.
+    component_structures : Mapping[str, Component]
+        A mapping from component IDs to components.
+
+    Returns
+    -------
+    bool
+        True if the reactions are equivalent, False otherwise.
+    
+    Warnings
+    --------
+    This function treats assemblies with different IDs as distinct, 
+    even if they are structurally identical. Please ensure that the 
+    assemblies in `id_to_assembly` are not duplicates.
+    """
+    # Condition 1: Same number of reactants and products
+    if reaction1.num_of_reactants != reaction2.num_of_reactants:
+        return False
+    if reaction1.num_of_products != reaction2.num_of_products:
+        return False
+    
+    # Condition 2: Same assemblies
+    if reaction1.init_assem_id != reaction2.init_assem_id:
+        return False
+    if reaction1.entering_assem_id is not None:
+        if reaction1.entering_assem_id != reaction2.entering_assem_id:
+            return False
+    if reaction1.product_assem_id != reaction2.product_assem_id:
+        return False
+    if reaction1.leaving_assem_id is not None:
+        if reaction1.leaving_assem_id != reaction2.leaving_assem_id:
+            return False
+
+    # Condition 3: Equivalent pair/trio of binding sites
+    if reaction1.num_of_reactants == 1:  # intra-reaction
+        if not are_equivalent_binding_site_lists(
+                id_to_assembly[reaction1.init_assem_id],
+                (reaction1.metal_bs, reaction1.leaving_bs,
+                 reaction1.entering_bs),
+                (reaction2.metal_bs, reaction2.leaving_bs,
+                 reaction2.entering_bs),
+                component_structures
+                ):
+            return False
+    elif reaction1.num_of_reactants == 2:  # inter-reaction
+        # Check for initial assembly
+        if not are_equivalent_binding_site_lists(
+                id_to_assembly[reaction1.init_assem_id],
+                (reaction1.metal_bs, reaction1.leaving_bs),
+                (reaction2.metal_bs, reaction2.leaving_bs),
+                component_structures
+                ):
+            return False
+        # Check for entering assembly
+        if not are_equivalent_binding_site_lists(
+                id_to_assembly[reaction1.entering_assem_id],
+                (reaction1.entering_bs,), (reaction2.entering_bs,),
+                component_structures
+                ):
+            return False
+    
+    assert reaction1.duplicate_count == reaction2.duplicate_count
+    return True

--- a/recsa/algorithms/tests/test_reaction_comparison.py
+++ b/recsa/algorithms/tests/test_reaction_comparison.py
@@ -1,0 +1,154 @@
+import pytest
+
+from recsa import Assembly, Component, InterReaction, IntraReaction
+from recsa.algorithms import are_equivalent_reactions
+
+
+@pytest.fixture
+def component_structures():
+    return {
+        'L': Component(['a', 'b']),
+        'M': Component(['a', 'b']),
+        'X': Component(['a']),
+    }
+
+
+@pytest.fixture
+def id_to_assembly():
+    return {
+        # MX2: X0(a)-(a)M0(b)-(a)X1
+        0: Assembly(
+            {'M0': 'M', 'X0': 'X', 'X1': 'X'},
+            [('X0.a', 'M0.a'), ('M0.b', 'X1.a')]
+        ),
+        1: Assembly({'L0': 'L'}),  # L: (a)L0(b)
+        2: Assembly({'X0': 'X'}),  # X: (a)X0
+        # MLX: (a)L0(b)-(a)M0(b)-(a)X0
+        3: Assembly(
+            {'M0': 'M', 'L0': 'L', 'X0': 'X'},
+            [('L0.b', 'M0.a'), ('M0.b', 'X0.a')]
+        ),
+        # ML2: (a)L0(b)-(a)M0(b)-(a)L1(b)
+        4: Assembly(
+            {'M0': 'M', 'L0': 'L', 'L1': 'L'},
+            [('L0.b', 'M0.a'), ('M0.b', 'L1.a')]
+        ),
+        # M2L2X: X0(a)-(a)M0(b)-(a)L0(b)-(a)M1(b)-(a)L1(b)
+        5: Assembly(
+            {'M0': 'M', 'M1': 'M', 'L0': 'L', 'L1': 'L', 'X0': 'X'},
+            [('X0.a', 'M0.a'), ('M0.b', 'L0.a'), ('L0.b', 'M1.a'), 
+             ('M1.b', 'L1.a')]
+        ),
+        # M2LX2: X0(a)-(a)M0(b)-(a)L0(b)-(a)M1(b)-(a)X1
+        6: Assembly(
+            {'M0': 'M', 'M1': 'M', 'L0': 'L', 'X0': 'X', 'X1': 'X'},
+            [('X0.a', 'M0.a'), ('M0.b', 'L0.a'), ('L0.b', 'M1.a'),
+             ('M1.b', 'X1.a')]
+        ),
+        # M2L2-ring: //-(a)M0(b)-(a)L0(b)-(a)M1(b)-(a)L1(b)-//
+        7: Assembly(
+            {'M0': 'M', 'M1': 'M', 'L0': 'L', 'L1': 'L'},
+            [('M0.b', 'L0.a'), ('L0.b', 'M1.a'), ('M1.b', 'L1.a'),
+             ('L1.b', 'M0.a')]
+        ),
+    }
+
+
+def test_inter_equivalence(component_structures, id_to_assembly):
+    # MX2 + L -> MLX + X
+    reaction1 = InterReaction(
+        init_assem_id=0,
+        entering_assem_id=1,
+        product_assem_id=3,
+        leaving_assem_id=2,
+        metal_bs='M0.a',
+        leaving_bs='X0.a',
+        entering_bs='L0.a',
+        duplicate_count=4,
+    )
+    # Same as above, but with different binding sites
+    reaction2 = InterReaction(
+        init_assem_id=0,
+        entering_assem_id=1,
+        product_assem_id=3,
+        leaving_assem_id=2,
+        metal_bs='M0.b',  # Different metal binding site
+        leaving_bs='X1.a',  # Different leaving binding site
+        entering_bs='L0.a',
+        duplicate_count=4,
+    )
+    # Although the metal and leaving binding sites are different,
+    # the pair of binding sites (metal, leaving) are equivalent, i.e.,
+    # (M0.a, X0.a) is equivalent to (M0.b, X1.a).
+    assert are_equivalent_reactions(
+        reaction1, reaction2, id_to_assembly, component_structures)
+
+
+def test_intra_equivalence(component_structures, id_to_assembly):
+    # Add an additional assembly M2L3
+    # M2L3: (a)L0(b)-(a)M0(b)-(a)L1(b)-(a)M1(b)-(a)L2(b)
+    id_to_assembly[8] = Assembly(
+        {'M0': 'M', 'M1': 'M', 'L0': 'L', 'L1': 'L', 'L2': 'L'},
+        [('L0.b', 'M0.a'), ('M0.b', 'L1.a'), ('L1.b', 'M1.a'),
+         ('M1.b', 'L2.a')]
+    )
+
+    # M2L3 is needed for "the equivalent intra-molecular reactions
+    # with different binding sites" described below.
+
+    # M2L3 -> M2L2-ring + L
+    reaction1 = IntraReaction(
+        init_assem_id=8,
+        product_assem_id=7,
+        leaving_assem_id=1,
+        metal_bs='M0.a',
+        leaving_bs='L0.b',
+        entering_bs='L2.b',
+        duplicate_count=2,
+    )
+    # Same as above, but with different binding sites
+    reaction2 = IntraReaction(
+        init_assem_id=8,
+        product_assem_id=7,
+        leaving_assem_id=1,
+        metal_bs='M1.b',  # Different metal binding site
+        leaving_bs='L2.a',  # Different leaving binding site
+        entering_bs='L0.a',
+        duplicate_count=2,
+    )
+    # Although the metal and leaving binding sites are different,
+    # the trio of binding sites (metal, leaving, entering) are equivalent, 
+    # i.e., (M0.a, L0.b, L2.b) is equivalent to (M1.b, L2.a, L0.a).
+    assert are_equivalent_reactions(
+        reaction1, reaction2, id_to_assembly, component_structures)
+
+
+def test_inter_intra_difference(component_structures, id_to_assembly):
+    # MX2 + L -> MLX + X
+    inter = InterReaction(
+        init_assem_id=0,
+        entering_assem_id=1,
+        product_assem_id=3,
+        leaving_assem_id=2,
+        metal_bs='M0.a',
+        leaving_bs='X0.a',
+        entering_bs='L0.a',
+        duplicate_count=1,
+    )
+    # M2L2X -> M2L2-ring + X
+    intra = IntraReaction(  # intra-molecular reaction
+        init_assem_id=5,
+        product_assem_id=7,
+        leaving_assem_id=2,
+        metal_bs='M0.a',
+        leaving_bs='X0.a',
+        entering_bs='L1.b',
+        duplicate_count=1,
+    )
+    # IntraReaction should not be equivalent to InterReaction
+    assert not are_equivalent_reactions(
+        inter, intra, id_to_assembly, component_structures)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
This pull request introduces a new function `are_equivalent_reactions` to check the equivalence of two chemical reactions and provides comprehensive unit tests to validate its functionality. The most important changes include adding the function implementation, updating the `__init__.py` file to expose the function, and creating detailed test cases.

### New functionality for reaction comparison:

* [`recsa/algorithms/reaction_comparison.py`](diffhunk://#diff-0d2ee7b4b83e32dec13b01cee8fb7a726dc4a5796c96b60ba0a9ea8f917c72d6R1-R107): Added the `are_equivalent_reactions` function to determine if two reactions (either inter- or intra-molecular) are equivalent based on specific conditions, including reactant/product counts, assembly equivalence, and binding site equivalence. The function includes detailed documentation and warnings about its behavior.

* [`recsa/algorithms/__init__.py`](diffhunk://#diff-9bb557ca9a38708a55fbfbd580b5e0afbb333ce024e4f591353905c9090199b2R32): Exposed the `are_equivalent_reactions` function for external use by adding it to the module imports.

### Unit tests for reaction equivalence:

* [`recsa/algorithms/tests/test_reaction_comparison.py`](diffhunk://#diff-333777f8859a36584d47c07c5514841d9990f1c5e73ab083b620c750f66360cfR1-R154): Added unit tests using `pytest` to validate the `are_equivalent_reactions` function. The tests include cases for inter-reaction equivalence, intra-reaction equivalence, and differentiation between inter- and intra-reactions. Fixtures for `component_structures` and `id_to_assembly` provide reusable test data.