### PR TITLE
Fix reaction exploration to double duplicate count for identical assemblies

### DIFF
--- a/recsa/reaction_exploration/inter.py
+++ b/recsa/reaction_exploration/inter.py
@@ -41,6 +41,8 @@ def explore_inter_reactions(
         entering_bs, entering_bs_dup_cnt = entering_bs_and_dup_cnt
 
         duplicate_count = ml_pair_dup_cnt * entering_bs_dup_cnt
+        if init_assem_id == entering_assem_id:
+            duplicate_count *= 2
 
         product, leaving = perform_inter_exchange(
             init_assem, entering_assem, metal_bs, leaving_bs, entering_bs)


### PR DESCRIPTION
This pull request introduces a small but significant change to the `explore_inter_reactions` function in `recsa/reaction_exploration/inter.py`. The change adjusts the calculation of `duplicate_count` to account for cases where `init_assem_id` matches `entering_assem_id`.

Key change:

* [`recsa/reaction_exploration/inter.py`](diffhunk://#diff-d17317231781e02df4ef57bc7070870ccc3647c9bc46f17e0ccb1c512f5bd745R44-R45): Added a condition to double the `duplicate_count` when `init_assem_id` equals `entering_assem_id`, ensuring the calculation reflects this specific scenario.