### PR TITLE
Implement cache clearing functions for several functions

### DIFF
--- a/recsa/reaction_exploration/lib/cached_self_isomorphism_iteration.py
+++ b/recsa/reaction_exploration/lib/cached_self_isomorphism_iteration.py
@@ -5,7 +5,11 @@ from cachetools import cached
 from recsa import Assembly, Component
 from recsa.algorithms import isomorphisms_iter
 
-__all__ = ['iter_self_isomorphisms_with_cache']
+_cache = {}  # type: ignore
+
+def clear_cache_for_iter_self_isomorphisms():
+    """Clear the cache used by `iter_self_isomorphisms_with_cache`."""
+    _cache.clear()
 
 
 def _cache_key(
@@ -16,7 +20,7 @@ def _cache_key(
     return assembly_id
 
 
-@cached(cache={}, key=_cache_key)
+@cached(cache=_cache, key=_cache_key)
 def iter_self_isomorphisms_with_cache(
         assembly_id: str, assembly: Assembly,
         component_structures: Mapping[str, Component]

--- a/recsa/reaction_exploration/lib/entering_bindsite_enumeration.py
+++ b/recsa/reaction_exploration/lib/entering_bindsite_enumeration.py
@@ -5,10 +5,14 @@ from cachetools.keys import hashkey
 
 from recsa import Assembly, Component
 
-__all__ = ['enum_valid_entering_bindsites']
+_cache = {}  # type: ignore
+
+def clear_cache_for_enum_valid_entering_bindsites():
+    """Clear the cache used by `enum_valid_entering_bindsites`."""
+    _cache.clear()
 
 
-def _cache_key2(
+def _cache_key(
         assembly_id: str | int,
         assembly: Assembly,
         entering_kind: str,
@@ -17,7 +21,7 @@ def _cache_key2(
     return hashkey(assembly_id, entering_kind)
 
 
-@cached(cache={}, key=_cache_key2)
+@cached(cache=_cache, key=_cache_key)
 def enum_valid_entering_bindsites(
         assembly_id: str | int,  # only used for caching
         assembly: Assembly,

--- a/recsa/reaction_exploration/lib/ml_pair_enumeration.py
+++ b/recsa/reaction_exploration/lib/ml_pair_enumeration.py
@@ -5,7 +5,11 @@ from cachetools.keys import hashkey
 
 from recsa import Assembly, Component
 
-__all__ = ['enum_valid_ml_pairs']
+_cache = {}  # type: ignore
+
+def clear_cache_for_enum_valid_ml_pairs():
+    """Clear the cache used by `enum_valid_ml_pairs`."""
+    _cache.clear()
 
 
 def _cache_key(
@@ -17,7 +21,7 @@ def _cache_key(
     return hashkey(assembly_id, metal_kind, leaving_kind)
 
 
-@cached(cache={}, key=_cache_key)
+@cached(cache=_cache, key=_cache_key)
 def enum_valid_ml_pairs(
         assembly_id: str | int,  # only used for caching
         assembly: Assembly,

--- a/recsa/reaction_exploration/lib/mle_enumeration_for_intra.py
+++ b/recsa/reaction_exploration/lib/mle_enumeration_for_intra.py
@@ -6,7 +6,11 @@ from cachetools.keys import hashkey
 
 from recsa import Assembly, Component
 
-__all__ = ['enum_valid_mles_for_intra']
+_cache = {}  # type: ignore
+
+def clear_cache_for_enum_valid_mles_for_intra():
+    """Clear the cache used by `enum_valid_mles_for_intra`."""
+    _cache.clear()
 
 
 def _cache_key(
@@ -18,7 +22,7 @@ def _cache_key(
     return hashkey(assembly_id, metal_kind, leaving_kind, entering_kind)
 
 
-@cached(cache={}, key=_cache_key)
+@cached(cache=_cache, key=_cache_key)
 def enum_valid_mles_for_intra(
         assembly_id: str | int,  # only used for caching
         assembly: Assembly,

--- a/recsa/reaction_exploration/lib/unique_bindsite_or_bindsite_sets.py
+++ b/recsa/reaction_exploration/lib/unique_bindsite_or_bindsite_sets.py
@@ -10,7 +10,11 @@ from recsa.utils import group_equivalent_nodes_or_nodesets
 from .cached_self_isomorphism_iteration import \
     iter_self_isomorphisms_with_cache
 
-__all__ = ['compute_unique_bindsites_or_bindsite_sets']
+_cache = {}  # type: ignore
+
+def clear_cache_for_compute_unique_bindsites_or_bindsite_sets():
+    """Clear the cache used by `compute_unique_bindsites_or_bindsite_sets`."""
+    _cache.clear()
 
 
 def _cache_key(
@@ -46,7 +50,7 @@ def compute_unique_bindsites_or_bindsite_sets(
         bindsites_or_bindsite_sets: Iterable[tuple[str, ...]],
         component_structures: Mapping[str, Component],
         ) -> list[tuple[tuple[str, ...], int]]: ...
-@cached(cache={}, key=_cache_key)
+@cached(cache=_cache, key=_cache_key)
 def compute_unique_bindsites_or_bindsite_sets(
         assembly_id,  # only used for caching
         assembly, bindsites_or_bindsite_sets, 


### PR DESCRIPTION
This pull request introduces caching improvements across multiple modules in the `recsa` library by replacing inline cache dictionaries with a shared `_cache` object and adding functions to clear these caches. 

These changes were made mainly for testing.

### Caching Improvements:

* **Introduction of shared `_cache` objects and cache-clearing functions:**
  - Added a `_cache` object to each module (`cached_self_isomorphism_iteration.py`, `entering_bindsite_enumeration.py`, `ml_pair_enumeration.py`, `mle_enumeration_for_intra.py`, and `unique_bindsite_or_bindsite_sets.py`) to replace inline cache dictionaries. Each module now includes a corresponding `clear_cache_*` function to clear the cache. [[1]](diffhunk://#diff-92663d644919336e495eefb5c664842437960b841defcf0a9e20f7309a350535L8-R12) [[2]](diffhunk://#diff-50f87112986354be552f7b7202c2949d259fa1bd7eccc1f5b55d17219df5cee9L8-R15) [[3]](diffhunk://#diff-dd64397ac443039b9e7c45b730fe467ffc98d13cda7b64b096850331c66a2597L8-R12) [[4]](diffhunk://#diff-f559450e7054111e4d060e1016dd8d7ac19ecd1843cc918696aec151bd8f0cb5L9-R13) [[5]](diffhunk://#diff-c034033e90c67fb7dc5675b6a56751aa73231c9b42fda31f6cb57cc3c7672e17L13-R17)

* **Refactoring of `@cached` decorators:**
  - Updated the `@cached` decorators in all affected modules to use the shared `_cache` object instead of creating new inline cache dictionaries. This ensures consistent cache usage across the modules. [[1]](diffhunk://#diff-92663d644919336e495eefb5c664842437960b841defcf0a9e20f7309a350535L19-R23) [[2]](diffhunk://#diff-50f87112986354be552f7b7202c2949d259fa1bd7eccc1f5b55d17219df5cee9L20-R24) [[3]](diffhunk://#diff-dd64397ac443039b9e7c45b730fe467ffc98d13cda7b64b096850331c66a2597L20-R24) [[4]](diffhunk://#diff-f559450e7054111e4d060e1016dd8d7ac19ecd1843cc918696aec151bd8f0cb5L21-R25) [[5]](diffhunk://#diff-c034033e90c67fb7dc5675b6a56751aa73231c9b42fda31f6cb57cc3c7672e17L49-R53)