### PR TITLE
Add verbose option to explore_reactions function and update tests

### DIFF
--- a/recsa/reaction_exploration/core.py
+++ b/recsa/reaction_exploration/core.py
@@ -1,6 +1,7 @@
 import itertools
 from collections import defaultdict
 from collections.abc import Iterator, Mapping
+from functools import wraps
 
 from recsa import (Assembly, Component, InterReaction, IntraReaction,
                    calc_graph_hash_of_assembly)
@@ -10,10 +11,25 @@ from .inter import explore_inter_reactions
 from .intra import explore_intra_reactions
 
 
+def _verbose(func):
+    """Decorator to add verbose logging to a function."""
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        verbose = kwargs.get('verbose', False)
+        reaction_iterator = func(*args, **kwargs)
+        for i, reaction in enumerate(reaction_iterator):
+            if verbose:
+                print(f'Reaction Found ({i}): {_reaction_to_str(reaction)}')
+            yield reaction
+    return wrapper
+
+
+@_verbose
 def explore_reactions(
         id_to_assembly: Mapping[int, Assembly],
         metal_kind: str, leaving_kind: str, entering_kind: str,
         component_structures: Mapping[str, Component],
+        verbose: bool = False,  # Used in the decorator
         ) -> Iterator[IntraReaction | InterReaction]:
     hash_to_ids = defaultdict(list)
     for assem_id, assembly in id_to_assembly.items():
@@ -33,3 +49,27 @@ def explore_reactions(
             init_assem_id, entering_assem_id, 
             metal_kind, leaving_kind, entering_kind,
             id_to_assembly, hash_to_ids, component_structures)
+
+
+def _reaction_to_str(
+        reaction: IntraReaction | InterReaction,
+        ) -> str:
+    init = reaction.init_assem_id
+    entering = reaction.entering_assem_id
+    product = reaction.product_assem_id
+    leaving = reaction.leaving_assem_id
+    
+    left = f'{init}' if entering is None else f'{init} + {entering}'
+    right = f'{product}' if leaving is None else f'{product} + {leaving}'
+    equation = f'{left} -> {right}'
+
+    metal_bs = reaction.metal_bs
+    leaving_bs = reaction.leaving_bs
+    entering_bs = reaction.entering_bs
+
+    binding_sites = (
+        f'metal={metal_bs}, leaving={leaving_bs}, entering={entering_bs}')
+    
+    dup = reaction.duplicate_count
+
+    return f'{equation} ({binding_sites}) (x{dup})'


### PR DESCRIPTION
This pull request introduces a new verbose logging feature for reaction exploration in the `recsa` package. The key changes include adding a decorator to enable verbose logging, a helper function to format reaction details, and a new test case to validate the verbose logging functionality.

### Enhancements to `explore_reactions`:

* Introduced a `_verbose` decorator to add optional verbose logging for the `explore_reactions` function. This logs details of each reaction found during iteration. (`recsa/reaction_exploration/core.py`, [recsa/reaction_exploration/core.pyR14-R32](diffhunk://#diff-ee7c64af70bc2b141ce4b37b2be5a53c55846eda0ad1e24f56e7e6624805bf60R14-R32))
* Added a `_reaction_to_str` helper function to format reaction details into a human-readable string, including binding sites and duplicate counts. (`recsa/reaction_exploration/core.py`, [recsa/reaction_exploration/core.pyR52-R75](diffhunk://#diff-ee7c64af70bc2b141ce4b37b2be5a53c55846eda0ad1e24f56e7e6624805bf60R52-R75))

### Testing:

* Added a new test case, `test_verbose`, to validate the verbose logging feature. It checks both the correctness of the reaction set and the accuracy of the logged output. (`recsa/reaction_exploration/tests/test_core.py`, [recsa/reaction_exploration/tests/test_core.pyR281-R402](diffhunk://#diff-9de2a5de0d619add0ba630d141400c4d210e6e5afd93a68358524847b57c58a8R281-R402))