### PR TITLE
Ensure reactions are converted to a list in reactions_to_df

### DIFF
--- a/recsa/pipelines/lib/reactions_df_conversion.py
+++ b/recsa/pipelines/lib/reactions_df_conversion.py
@@ -9,6 +9,7 @@ Reaction: TypeAlias = IntraReaction | InterReaction
 
 
 def reactions_to_df(reactions: Iterable[Reaction]) -> pd.DataFrame:
+    reactions = list(reactions)
     df = pd.DataFrame(
         [reaction.to_dict() for reaction in reactions],
         columns=[


### PR DESCRIPTION
This pull request makes a small change to the `reactions_to_df` function in `recsa/pipelines/lib/reactions_df_conversion.py`. The change ensures that the `reactions` parameter is explicitly converted to a list before processing.

It prevents errors occurs when an iterator is passed.