### PR TITLE
Add explore_reactions_pipeline and corresponding tests

### DIFF
--- a/recsa/pipelines/__init__.py
+++ b/recsa/pipelines/__init__.py
@@ -6,3 +6,4 @@ from .bindsite_capping import cap_bindsites_pipeline
 from .bondset_enumeration import enum_bond_subsets_pipeline
 from .bondset_to_assembly import bondsets_to_assemblies_pipeline
 from .duplicate_exclusion import find_unique_assemblies_pipeline
+from .reaction_exploration import explore_reactions_pipeline

--- a/recsa/pipelines/reaction_exploration.py
+++ b/recsa/pipelines/reaction_exploration.py
@@ -1,0 +1,67 @@
+import os
+
+import pandas as pd
+
+from recsa import explore_reactions
+
+from .lib import reactions_to_df, read_file
+
+
+def explore_reactions_pipeline(
+        assemblies_path: os.PathLike | str,
+        components_path: os.PathLike | str,
+        config_path: os.PathLike | str,
+        output_path: os.PathLike | str,
+        *,
+        overwrite: bool = False,
+        verbose: bool = False,
+        ) -> None:
+    id_to_assembly = read_file(assemblies_path)
+    config = read_file(config_path)
+    components = read_file(components_path)
+    
+    metal_kind = config['mle_kinds']['metal']
+    leaving_kind = config['mle_kinds']['leaving']
+    entering_kind = config['mle_kinds']['entering']
+
+    component_kinds = components['component_kinds']
+
+    if verbose:
+        print('Enumerating reactions...')
+        
+    result = explore_reactions(
+        id_to_assembly,
+        metal_kind=metal_kind,
+        leaving_kind=leaving_kind,
+        entering_kind=entering_kind,
+        component_structures=component_kinds,
+        verbose=verbose,
+    )
+
+    if verbose:
+        print('Reaction enumeration completed.')
+
+    # Output
+    _write_output(
+        output_path, reactions_to_df(result),
+        overwrite=overwrite,
+        verbose=verbose,
+    )
+
+
+def _write_output(
+        output_path: os.PathLike | str, reaction_df: pd.DataFrame,
+        *,
+        overwrite: bool = False,
+        verbose: bool = False,
+        ) -> None:
+    if not overwrite and os.path.exists(output_path):
+        raise FileExistsError(f'Output file "{output_path}" already exists.')
+    if verbose:
+        print(f'Saving the results to "{output_path}"...')
+    dir_ = os.path.dirname(output_path)
+    if dir_:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    reaction_df.to_csv(output_path, index=False)
+    if verbose:
+        print(f'Successfully saved to "{output_path}".')

--- a/recsa/pipelines/tests/test_reaction_exploration.py
+++ b/recsa/pipelines/tests/test_reaction_exploration.py
@@ -1,0 +1,156 @@
+from typing import TypeAlias
+
+import pandas as pd
+import pytest
+import yaml
+
+from recsa import Assembly, Component, InterReaction, IntraReaction
+from recsa.pipelines import explore_reactions_pipeline
+
+Reaction: TypeAlias = InterReaction | IntraReaction
+
+def test_comprehensive_reaction_sets(tmpdir):
+    components_data = {
+        'component_kinds': {
+        'M': Component(['a', 'b']),
+        'L': Component(['a', 'b']),
+        'X': Component(['a']),
+        }
+    }
+
+    id_to_assembly = {
+        # MX2: X0(a)-(a)M0(b)-(a)X1
+        0: Assembly(
+            {'M0': 'M', 'X0': 'X', 'X1': 'X'},
+            [('X0.a', 'M0.a'), ('M0.b', 'X1.a')]
+        ),
+        1: Assembly({'L0': 'L'}),  # L: (a)L0(b)
+        2: Assembly({'X0': 'X'}),  # X: (a)X0
+        # MLX: (a)L0(b)-(a)M0(b)-(a)X0
+        3: Assembly(
+            {'M0': 'M', 'L0': 'L', 'X0': 'X'},
+            [('L0.b', 'M0.a'), ('M0.b', 'X0.a')]
+        ),
+        # ML2: (a)L0(b)-(a)M0(b)-(a)L1(b)
+        4: Assembly(
+            {'M0': 'M', 'L0': 'L', 'L1': 'L'},
+            [('L0.b', 'M0.a'), ('M0.b', 'L1.a')]
+        ),
+        # M2L2X: X0(a)-(a)M0(b)-(a)L0(b)-(a)M1(b)-(a)L1(b)
+        5: Assembly(
+            {'M0': 'M', 'M1': 'M', 'L0': 'L', 'L1': 'L', 'X0': 'X'},
+            [('X0.a', 'M0.a'), ('M0.b', 'L0.a'), ('L0.b', 'M1.a'),
+             ('M1.b', 'L1.a')]
+        ),
+        # M2LX2: X0(a)-(a)M0(b)-(a)L0(b)-(a)M1(b)-(a)X1
+        6: Assembly(
+            {'M0': 'M', 'M1': 'M', 'L0': 'L', 'X0': 'X', 'X1': 'X'},
+            [('X0.a', 'M0.a'), ('M0.b', 'L0.a'), ('L0.b', 'M1.a'),
+             ('M1.b', 'X1.a')]
+        ),
+        # M2L2-ring: //-(a)M0(b)-(a)L0(b)-(a)M1(b)-(a)L1(b)-//
+        7: Assembly(
+            {'M0': 'M', 'M1': 'M', 'L0': 'L', 'L1': 'L'},
+            [('M0.b', 'L0.a'), ('L0.b', 'M1.a'), ('M1.b', 'L1.a'),
+             ('L1.b', 'M0.a')]
+        ),
+    }
+
+    config = {
+        'mle_kinds': {
+            'metal': 'M',
+            'leaving': 'X',
+            'entering': 'L',
+        }
+    }
+
+    # Create input files
+    assemblies_path = tmpdir / 'assemblies.yaml'
+    components_path = tmpdir / 'components.yaml'
+    config_path = tmpdir / 'config.yaml'
+    output_path = tmpdir / 'reactions.csv'
+
+    with open(assemblies_path, 'w') as f:
+        yaml.dump(id_to_assembly, f)
+    with open(components_path, 'w') as f:
+        yaml.dump(components_data, f)
+    with open(config_path, 'w') as f:
+        yaml.dump(config, f)
+
+    expected_reactions: dict[str, Reaction] = {
+        # Intra-molecular reactions
+        'M2L2X -> M2L2-ring + X': IntraReaction(
+            init_assem_id=5, 
+            product_assem_id=7, leaving_assem_id=2, 
+            metal_bs='M0.a', leaving_bs='X0.a', entering_bs='L1.b',
+            duplicate_count=1,
+        ),
+        # Inter-molecular reactions
+        'MX2 + L -> MLX + X': InterReaction(
+            init_assem_id=0, entering_assem_id=1,
+            product_assem_id=3, leaving_assem_id=2,
+            metal_bs='M0.a', leaving_bs='X0.a', entering_bs='L0.a',
+            duplicate_count=4,
+        ),
+        'MX2 + MLX -> M2LX2 + X': InterReaction(
+            init_assem_id=0, entering_assem_id=3,
+            product_assem_id=6, leaving_assem_id=2,
+            metal_bs='M0.a', leaving_bs='X0.a', entering_bs='L0.a',
+            duplicate_count=2,
+        ),
+        'MX2 + ML2 -> M2L2X + X': InterReaction(
+            init_assem_id=0, entering_assem_id=4,
+            product_assem_id=5, leaving_assem_id=2,
+            metal_bs='M0.a', leaving_bs='X0.a', entering_bs='L0.a',
+            duplicate_count=4,
+        ),
+        'MLX + L -> ML2 + X': InterReaction(
+            init_assem_id=3, entering_assem_id=1,
+            product_assem_id=4, leaving_assem_id=2,
+            metal_bs='M0.b', leaving_bs='X0.a', entering_bs='L0.a',
+            duplicate_count=2,
+        ),
+        'MLX + MLX -> M2L2X + X': InterReaction(
+            init_assem_id=3, entering_assem_id=3,
+            product_assem_id=5, leaving_assem_id=2,
+            metal_bs='M0.b', leaving_bs='X0.a', entering_bs='L0.a',
+            duplicate_count=2,
+        ),
+        'M2LX2 + L -> M2L2X + X': InterReaction(
+            init_assem_id=6, entering_assem_id=1,
+            product_assem_id=5, leaving_assem_id=2,
+            metal_bs='M0.a', leaving_bs='X0.a', entering_bs='L0.a',
+            duplicate_count=4,
+        ),
+    }
+
+    expected_csv = """\
+init_assem_id,entering_assem_id,product_assem_id,leaving_assem_id,metal_bs,leaving_bs,entering_bs,duplicate_count
+5,,7,2,M0.a,X0.a,L1.b,1
+0,1,3,2,M0.a,X0.a,L0.a,4
+0,3,6,2,M0.a,X0.a,L0.a,2
+0,4,5,2,M0.a,X0.a,L0.a,4
+3,1,4,2,M0.b,X0.a,L0.a,2
+3,3,5,2,M0.b,X0.a,L0.a,2
+6,1,5,2,M0.a,X0.a,L0.a,4
+"""
+
+    # Run the pipeline
+    explore_reactions_pipeline(
+        assemblies_path=assemblies_path,
+        components_path=components_path,
+        config_path=config_path,
+        output_path=output_path,
+        overwrite=True, verbose=True
+    )
+
+    # Read the output CSV
+    with open(output_path, 'r') as f:
+        output_csv = f.read()
+
+    # Check if the output CSV matches the expected CSV
+    assert output_csv == expected_csv
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
This pull request introduces a new pipeline for reaction exploration, including its implementation, integration, and comprehensive testing. The most important changes include adding the `explore_reactions_pipeline` function, integrating it into the pipeline module, and creating a detailed test suite to validate its functionality.

### New Reaction Exploration Pipeline

* Added the `explore_reactions_pipeline` function in `recsa/pipelines/reaction_exploration.py`. This function reads input data, enumerates reactions using the `explore_reactions` module, and writes the results to a CSV file. It supports options for verbose output and overwriting existing files.

* Integrated the new `explore_reactions_pipeline` function into the pipeline module by importing it in `recsa/pipelines/__init__.py`.

### Testing

* Created a new test file, `recsa/pipelines/tests/test_reaction_exploration.py`, to validate the functionality of the `explore_reactions_pipeline`. The test includes:
  - Mock input data for assemblies, components, and configuration.
  - Expected output in CSV format.
  - Assertions to ensure the pipeline produces the correct results.