### PR TITLE
Add explore_reactions CLI command and corresponding tests

### DIFF
--- a/recsa/cli/commands.py
+++ b/recsa/cli/commands.py
@@ -1,7 +1,8 @@
 import click
 
 from recsa.pipelines import (concatenate_assemblies_pipeline,
-                             enumerate_assemblies_pipeline)
+                             enumerate_assemblies_pipeline,
+                             explore_reactions_pipeline)
 
 
 @click.command('enumerate-assemblies')
@@ -87,3 +88,35 @@ def run_concat_assembly_lists_pipeline(
         already_unique_within_files=already_unique_within_files,
         skip_isomorphism_checks=skip_isomorphism_checks,
         start=start, overwrite=overwrite, verbose=verbose)
+
+
+@click.command('explore-reactions')
+@click.argument('assemblies', type=click.Path(exists=True))
+@click.argument('component_kinds', type=click.Path(exists=True))
+@click.argument('config', type=click.Path(exists=True))
+@click.argument('output', type=click.Path())
+@click.option(
+    '--overwrite', '-o', is_flag=True,
+    help='Overwrite output file if it exists.')
+@click.option(
+    '--verbose', '-v', is_flag=True,
+    help='Print verbose output.')
+def run_explore_reactions_pipeline(
+        assemblies, component_kinds, config, output, overwrite, verbose):
+    """Explores reactions in assemblies.
+    \b
+    Parameters
+    ----------
+    - ASSEMBLIES: Path to input file of assemblies.
+    - COMPONENT_KINDS: Path to input file of component kinds.
+    - CONFIG: Path to input file of configuration.
+    - OUTPUT: Path to output file.
+    \b
+    Options
+    -------
+    --overwrite, -o: Overwrite output file if it exists.
+    --verbose, -v: Print verbose output.
+    """
+    explore_reactions_pipeline(
+        assemblies, component_kinds, config, output,
+        overwrite=overwrite, verbose=verbose)

--- a/recsa/cli/main.py
+++ b/recsa/cli/main.py
@@ -1,7 +1,8 @@
 import click
 
 from recsa.cli.commands import (run_concat_assembly_lists_pipeline,
-                                run_enum_assemblies_pipeline)
+                                run_enum_assemblies_pipeline,
+                                run_explore_reactions_pipeline)
 
 
 @click.group()
@@ -12,3 +13,4 @@ def main():
 
 main.add_command(run_concat_assembly_lists_pipeline)
 main.add_command(run_enum_assemblies_pipeline)
+main.add_command(run_explore_reactions_pipeline)

--- a/recsa/cli/tests/test_reaction_exploration.py
+++ b/recsa/cli/tests/test_reaction_exploration.py
@@ -1,0 +1,119 @@
+import os
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from recsa import Assembly, Component
+from recsa.cli.commands import run_explore_reactions_pipeline
+
+
+@pytest.fixture
+def components_data():
+    return {
+        'component_kinds': {
+        'M': Component(['a', 'b']),
+        'L': Component(['a', 'b']),
+        'X': Component(['a']),
+        }
+    }
+
+
+@pytest.fixture
+def assemblies():
+    return {
+        # MX2: X0(a)-(a)M0(b)-(a)X1
+        0: Assembly(
+            {'M0': 'M', 'X0': 'X', 'X1': 'X'},
+            [('X0.a', 'M0.a'), ('M0.b', 'X1.a')]
+        ),
+        1: Assembly({'L0': 'L'}),  # L: (a)L0(b)
+        2: Assembly({'X0': 'X'}),  # X: (a)X0
+        # MLX: (a)L0(b)-(a)M0(b)-(a)X0
+        3: Assembly(
+            {'M0': 'M', 'L0': 'L', 'X0': 'X'},
+            [('L0.b', 'M0.a'), ('M0.b', 'X0.a')]
+        ),
+        # ML2: (a)L0(b)-(a)M0(b)-(a)L1(b)
+        4: Assembly(
+            {'M0': 'M', 'L0': 'L', 'L1': 'L'},
+            [('L0.b', 'M0.a'), ('M0.b', 'L1.a')]
+        ),
+        # M2L2X: X0(a)-(a)M0(b)-(a)L0(b)-(a)M1(b)-(a)L1(b)
+        5: Assembly(
+            {'M0': 'M', 'M1': 'M', 'L0': 'L', 'L1': 'L', 'X0': 'X'},
+            [('X0.a', 'M0.a'), ('M0.b', 'L0.a'), ('L0.b', 'M1.a'),
+             ('M1.b', 'L1.a')]
+        ),
+        # M2LX2: X0(a)-(a)M0(b)-(a)L0(b)-(a)M1(b)-(a)X1
+        6: Assembly(
+            {'M0': 'M', 'M1': 'M', 'L0': 'L', 'X0': 'X', 'X1': 'X'},
+            [('X0.a', 'M0.a'), ('M0.b', 'L0.a'), ('L0.b', 'M1.a'),
+             ('M1.b', 'X1.a')]
+        ),
+        # M2L2-ring: //-(a)M0(b)-(a)L0(b)-(a)M1(b)-(a)L1(b)-//
+        7: Assembly(
+            {'M0': 'M', 'M1': 'M', 'L0': 'L', 'L1': 'L'},
+            [('M0.b', 'L0.a'), ('L0.b', 'M1.a'), ('M1.b', 'L1.a'),
+             ('L1.b', 'M0.a')]
+        ),
+    }
+
+
+@pytest.fixture
+def config():
+    return {
+        'mle_kinds': {
+            'metal': 'M',
+            'leaving': 'X',
+            'entering': 'L',
+        }
+    }
+
+
+@pytest.fixture
+def expected_csv():
+    return """\
+init_assem_id,entering_assem_id,product_assem_id,leaving_assem_id,metal_bs,leaving_bs,entering_bs,duplicate_count
+5,,7,2,M0.a,X0.a,L1.b,1
+0,1,3,2,M0.a,X0.a,L0.a,4
+0,3,6,2,M0.a,X0.a,L0.a,2
+0,4,5,2,M0.a,X0.a,L0.a,4
+3,1,4,2,M0.b,X0.a,L0.a,2
+3,3,5,2,M0.b,X0.a,L0.a,2
+6,1,5,2,M0.a,X0.a,L0.a,4
+"""
+
+
+def test_run_enum_assemblies_pipeline(
+        tmp_path, assemblies, components_data, config, expected_csv):
+    runner = CliRunner()
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        assemblies_path = os.path.join(td, 'assemblies.yaml')
+        components_path = os.path.join(td, 'components.yaml')
+        config_path = os.path.join(td, 'config.yaml')
+        output_path = os.path.join(td, 'output.csv')
+
+        with open(assemblies_path, 'w') as f:
+            yaml.dump(assemblies, f)
+        with open(components_path, 'w') as f:
+            yaml.dump(components_data, f)
+        with open(config_path, 'w') as f:
+            yaml.dump(config, f)
+
+        result = runner.invoke(
+            run_explore_reactions_pipeline, [
+                str(assemblies_path), str(components_path),
+                str(config_path), str(output_path),
+                '--overwrite', '--verbose'])
+
+        assert result.exit_code == 0
+
+        with open(output_path, 'r') as f:
+            output_data = f.read()
+        assert output_data == expected_csv
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This pull request introduces a new CLI command, `explore-reactions`, to analyze reactions in assemblies. It also includes a comprehensive test suite to ensure the functionality of the new command. The most important changes are grouped below by theme:

### Addition of the `explore-reactions` CLI Command:
* Added a new pipeline function, `explore_reactions_pipeline`, to the imports in `recsa/cli/commands.py`. This function handles the core logic for exploring reactions.
* Introduced the `run_explore_reactions_pipeline` function in `recsa/cli/commands.py`, which defines the `explore-reactions` CLI command, its arguments, options, and documentation.
* Registered the new `explore-reactions` command in the CLI entry point (`main`) in `recsa/cli/main.py`. [[1]](diffhunk://#diff-4af3bf0b112be3175aecd49a387a5927c66373d1875e230363a8efd07303c396L4-R5) [[2]](diffhunk://#diff-4af3bf0b112be3175aecd49a387a5927c66373d1875e230363a8efd07303c396R16)

### Testing for the New Command:
* Added a new test file, `recsa/cli/tests/test_reaction_exploration.py`, which includes:
  - Fixtures for test data, such as components, assemblies, configurations, and expected CSV output.
  - A test case to verify the functionality of the `explore-reactions` command, ensuring it produces the correct output based on the provided inputs.