### PR TITLE
Bump version to 0.15.0 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "recsa"
-version = "0.14.2"
+version = "0.15.0"
 description = "Reaction Explorer for Coordination Self-Assembly"
 authors = ["neji-craftsman <142223934+neji-craftsman@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
This pull request updates the version of the `recsa` package in the `pyproject.toml` file to reflect a new release.

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the `version` field from `0.14.2` to `0.15.0` to indicate a new version of the package.